### PR TITLE
refactor: resolve selection points from snap ids

### DIFF
--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -48,4 +48,4 @@
 | 42 | `docs/specs/storage/storage_adapter_spec.md` | Active | 保存機能の無料/有料切替を支えるStorageAdapter仕様を定義する。 | 2026-01-17T17:18:01+09:00 | 2026-01-18T02:42:11+09:00 |
 | 43 | `docs/specs/ui/ui_spec.md` | Active | 現行UIの仕様（サイドバー/ヘッダー/プリセット/設定/学習）を定義する。 | 2026-01-18T16:15:17+09:00 | 2026-01-19T08:21:11+09:00 |
 | 44 | `docs/testing/verification_plan.md` | Active | 構造主体移行後の正確性・教育機能・数値安定性の検証計画を定義する。 | 2026-01-17T17:18:01+09:00 | 2026-01-18T02:42:11+09:00 |
-| 45 | `docs/workflow.md` | Active | Issue/PR 駆動の作業手順と命名規則を定義する。 | - | - |
+| 45 | `docs/workflow.md` | Active | Issue/PR 駆動の作業手順と命名規則を定義する。 | 2026-01-19T11:06:02+09:00 | 2026-01-19T11:06:02+09:00 |

--- a/docs/architecture/object_model_spec.md
+++ b/docs/architecture/object_model_spec.md
@@ -10,12 +10,13 @@ Summary: アプリ全体を対象に、立体・切断・展開図の要素を�
 ## 前提
 - 既存の構造主体アーキテクチャ（Vertex/Edge/Face/SnapPoint）を拡張する。
 - 描画は View 層の責務とし、モデルは状態と関係性のみを持つ。
+- 座標は GeometryResolver により解決される派生情報であり、移行期間は参照を容易にするため一時的に保持する。
 
 ## モデル構成（最小）
 
 ### Vertex
 - `id`: VertexID (例: `V:0`)
-- `position`: THREE.Vector3 (ワールド座標)
+- `position`: THREE.Vector3 (派生情報としてのワールド座標)
 - `label`: string (表示ラベル)
 - `flags`: { selected, hovered, isCutPoint, isSnapPoint }
 

--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -244,6 +244,14 @@ Summary:
 Notes:
 - legacy DOM を前提とした UI 更新を段階的に縮退
 
+## 2026-01-19T10:26:30+09:00
+Summary:
+- SelectionManager の選択状態を SnapPointID 起点に整理し、座標保持を最小化
+- 既存の同一直線チェックは必要時に Resolver から座標を解決する方式へ変更
+
+Notes:
+- 座標は派生情報として扱い、今後も保持箇所を削減していく
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/js/SelectionManager.ts
+++ b/js/SelectionManager.ts
@@ -8,7 +8,7 @@ export class SelectionManager {
   cube: any;
   ui: any;
   resolver: any;
-  selected: Array<{ snapId: SnapPointID; point: THREE.Vector3; object?: THREE.Object3D; isMidpoint?: boolean }>;
+  selected: Array<{ snapId: SnapPointID }>;
   markers: THREE.Object3D[];
   splitEdgeLabels: THREE.Object3D[];
   hiddenEdgeLabels: number[];
@@ -22,7 +22,7 @@ export class SelectionManager {
     this.cube = cube;
     this.ui = ui;
     this.resolver = resolver;
-    this.selected = []; // オブジェクトの配列 { snapId, point, object, isMidpoint }
+    this.selected = []; // オブジェクトの配列 { snapId }
     this.markers = []; // 赤丸、点ラベル、辺ラベル(分割分) 全て含むが、管理しやすくする
     this.splitEdgeLabels = []; // 分割辺の長さラベルだけ別途保持
     this.hiddenEdgeLabels = []; // 隠した元の辺ラベルのインデックス
@@ -90,7 +90,7 @@ export class SelectionManager {
         }
     }
 
-    this.selected.push({ snapId, point: resolvedPoint, object, isMidpoint: resolvedIsMidpoint });
+    this.selected.push({ snapId });
     if (object) this.selectedObjects.add(object.uuid);
     
     const li = this.selected.length - 1;
@@ -123,6 +123,13 @@ export class SelectionManager {
   addPointFromSnapId(snapId: SnapPointID, selectionInfo: Record<string, unknown> = {}) {
     if (!this.resolver) return;
     this.addPoint({ ...selectionInfo, snapId });
+  }
+
+  getSelectedPoint(index: number) {
+    if (!this.resolver) return null;
+    const target = this.selected[index];
+    if (!target) return null;
+    return this.resolver.resolveSnapPoint(target.snapId) || null;
   }
 
   getSelectedSnapIds() {

--- a/main.ts
+++ b/main.ts
@@ -590,14 +590,16 @@ class App {
         if (this.selection.isObjectSelected(this.snappedPointInfo.object)) return;
 
         if (this.selection.selected.length === 2) {
-            const p0 = this.selection.selected[0].point;
-            const p1 = this.selection.selected[1].point;
+            const p0 = this.selection.getSelectedPoint(0);
+            const p1 = this.selection.getSelectedPoint(1);
             const p2 = this.snappedPointInfo.point;
-            const v1 = new THREE.Vector3().subVectors(p1, p0);
-            const v2 = new THREE.Vector3().subVectors(p2, p0);
-            if (v1.cross(v2).lengthSq() < 1e-6) {
-                this.ui.showMessage("3つの点が同一直線上になるため、選択できません。", "warning");
-                return;
+            if (p0 && p1 && p2) {
+                const v1 = new THREE.Vector3().subVectors(p1, p0);
+                const v2 = new THREE.Vector3().subVectors(p2, p0);
+                if (v1.cross(v2).lengthSq() < 1e-6) {
+                    this.ui.showMessage("3つの点が同一直線上になるため、選択できません。", "warning");
+                    return;
+                }
             }
         }
         if (this.selection.selected.length >= 3) return;


### PR DESCRIPTION
## 変更点\n- SelectionManager の選択状態を SnapPointID のみ保持に変更\n- 同一直線チェックを Resolver の座標解決に変更\n- object_model_spec に派生情報としての座標扱いを追記\n- worklog と DOCS_INDEX を更新\n\n## 理由\n- 座標を真実として保持せず、SnapPointID を正として扱うため\n\n## テスト\n- [x] npm run typecheck\n- [x] npm test\n\n## 影響/リスク\n- Resolver が座標を返せない場合、同一直線チェックをスキップ\n\n## 関連Issue\n- Refs #8\n\n## 依存関係\n- Depends on なし\n