### PR TITLE
#9 [TASK] 座標依存の棚卸しと分類

### DIFF
--- a/docs/migration/coordinate_dependency_inventory.md
+++ b/docs/migration/coordinate_dependency_inventory.md
@@ -1,0 +1,52 @@
+# coordinate_dependency_inventory.md
+
+Status: Active
+Summary: 座標依存箇所を棚卸しし、SnapPointID/Resolver 起点への移行優先度を整理する。
+
+## 目的
+- 座標を真実として保持している箇所を洗い出す
+- SnapPointID/Resolver 起点へ移行する順序を明確にする
+- 「常に動く状態」を維持しながら段階移行する
+
+## 依存分類
+### A. 状態として座標を保持している
+- Object Model
+  - `js/model/objectModel.ts`: `ObjectVertex.position`, `ObjectFace.normal/uvBasis`, `ObjectCutSegment.start/end`, `ObjectNetState.targetCenter/positionTarget` など
+  - `js/model/objectModelBuilder.ts`: Resolver で座標を構築してモデルに保持
+- Cutter
+  - `js/Cutter.ts`: `IntersectionPoint.position` や `cutSegments` に `start/end` を保持
+- main
+  - `main.ts`: 展開図生成用の `cutFace.vertices` などが `THREE.Vector3` で保持される
+
+### B. 描画時に Resolver で都度解決
+- Selection/Interaction
+  - `main.ts`: SnapPointID から `resolver.resolveVertex/resolveEdge/resolveSnapPoint` を使い選択座標を取得
+  - `js/SelectionManager.ts`: SnapPointID から `resolveEdge/resolveSnapPoint` を使いラベル位置を計算
+- Net
+  - `js/net/NetManager.ts`: faceId から `resolver.resolveFace/resolveVertex` を使って投影
+
+### C. 一時的な計算のみ（保持しない）
+- `main.ts` のアニメーション補間や描画用の一時 `Vector3` 計算
+- GeometryResolver 内部の算出値（都度生成）
+
+## 影響範囲（主要ファイル）
+- `main.ts`
+  - 展開図生成/投影/ラベル描画で座標配列を扱う
+- `js/Cutter.ts`
+  - 交点/切断線の計算結果に座標が含まれる
+- `js/net/NetManager.ts`
+  - 面投影で Resolver を利用しつつも座標配列を扱う
+- `js/model/*`
+  - モデルが座標を保持する設計
+
+## 移行優先度（提案）
+1) Cut/交点/切断線の保持を SnapPointID 起点に整理
+   - `IntersectionPoint.position` や `cutSegments.start/end` を派生情報へ寄せる
+2) Net 展開の投影/面同定を Resolver 起点に統一
+   - 面/辺の同定に座標フォールバックを持たない構成へ
+3) Object Model の座標保持を段階的に削減
+   - `ObjectVertex.position` などを派生情報扱いにして最終的に削除
+
+## 次のアクション
+- Issue #10/#11/#12/#13 の順に詳細移行計画へ落とし込む
+- 既存仕様ドキュメントの座標依存表現を整理

--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -252,6 +252,14 @@ Summary:
 Notes:
 - 座標は派生情報として扱い、今後も保持箇所を削減していく
 
+## 2026-01-19T11:24:43+09:00
+Summary:
+- 座標依存の棚卸しドキュメントを追加
+- SnapPointID/Resolver 起点の移行優先度案を整理
+
+Notes:
+- Issue #9 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理


### PR DESCRIPTION
## 変更点\n- 座標依存の棚卸しドキュメントを追加\n- 既存の移行ログに棚卸し実施を記録\n\n## 理由\n- SnapPointID/Resolver 起点への移行順序を明確にするため\n\n## テスト\n- [ ] npm run typecheck\n- [ ] npm test\n\n## 影響/リスク\n- なし（ドキュメントのみ）\n\n## 関連Issue\n- Refs #9\n\n## 依存関係\n- Depends on なし\n