### PR TITLE
#10 [REF] Object Modelの座標保持を派生情報として整理

### DIFF
--- a/docs/architecture/object_model_spec.md
+++ b/docs/architecture/object_model_spec.md
@@ -12,6 +12,11 @@ Summary: アプリ全体を対象に、立体・切断・展開図の要素を�
 - 描画は View 層の責務とし、モデルは状態と関係性のみを持つ。
 - 座標は GeometryResolver により解決される派生情報であり、移行期間は参照を容易にするため一時的に保持する。
 
+## 派生情報の扱い
+- `position` / `normal` / `uvBasis` / `length` などの幾何値は派生情報として扱う。
+- 真実は SnapPointID と構造モデルに置き、派生情報は再計算可能であることを前提にする。
+- 移行完了後は派生情報をモデルから除去できる状態を目指す。
+
 ## モデル構成（最小）
 
 ### Vertex
@@ -24,7 +29,7 @@ Summary: アプリ全体を対象に、立体・切断・展開図の要素を�
 - `id`: EdgeID (例: `E:01`)
 - `v1`, `v2`: Vertex 参照
 - `faces`: FaceID[]
-- `length`: number
+- `length`: number (派生情報)
 - `flags`: { selected, hovered, isCutEdge, hasCutPoint, isMidpointCut }
   - `hasCutPoint` / `isMidpointCut` は切断線の色分け判定に利用
 
@@ -32,8 +37,8 @@ Summary: アプリ全体を対象に、立体・切断・展開図の要素を�
 - `id`: FaceID (例: `F:0154`)
 - `vertices`: Vertex[]
 - `edges`: Edge[]
-- `normal`: THREE.Vector3
-- `uvBasis`: { origin: THREE.Vector3, u: THREE.Vector3, v: THREE.Vector3 }
+- `normal`: THREE.Vector3 (派生情報)
+- `uvBasis`: { origin: THREE.Vector3, u: THREE.Vector3, v: THREE.Vector3 } (派生情報)
 - `flags`: { selected, hovered, isCutFace, isOriginalFace }
 - `polygons`: FacePolygon[] (切断後の分割面)
 

--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -260,6 +260,14 @@ Summary:
 Notes:
 - Issue #9 の成果物として更新
 
+## 2026-01-19T11:28:51+09:00
+Summary:
+- Object Model の座標/法線/uvBasis/長さを派生情報として明記
+- Resolver 起点の生成方針をコード側に追記
+
+Notes:
+- Issue #10 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/js/model/objectModel.ts
+++ b/js/model/objectModel.ts
@@ -27,6 +27,7 @@ export type ObjectVertex = {
   id: string;
   index: number;
   label: string | null;
+  // Derived from GeometryResolver; not source of truth.
   position: THREE.Vector3;
   flags: ObjectVertexFlags;
 };
@@ -35,6 +36,7 @@ export type ObjectEdge = {
   id: string;
   vertices: [ObjectVertex, ObjectVertex];
   faces: string[];
+  // Derived from GeometryResolver; not source of truth.
   length: number;
   flags: ObjectEdgeFlags;
 };
@@ -43,7 +45,9 @@ export type ObjectFace = {
   id: string;
   vertices: ObjectVertex[];
   edges: ObjectEdge[];
+  // Derived from GeometryResolver; not source of truth.
   normal: THREE.Vector3;
+  // Derived from GeometryResolver; not source of truth.
   uvBasis: { origin: THREE.Vector3; u: THREE.Vector3; v: THREE.Vector3 };
   flags: ObjectFaceFlags;
   polygons: unknown[];
@@ -60,7 +64,9 @@ export type ObjectSolid = {
 export type ObjectCutSegment = {
   startId: SnapPointID;
   endId: SnapPointID;
+  // Derived from GeometryResolver; not source of truth.
   start: THREE.Vector3;
+  // Derived from GeometryResolver; not source of truth.
   end: THREE.Vector3;
   faceIds?: string[];
 };
@@ -68,6 +74,7 @@ export type ObjectCutSegment = {
 export type ObjectCutAdjacency = {
   a: string;
   b: string;
+  // Derived from GeometryResolver; not source of truth.
   sharedEdge: [THREE.Vector3, THREE.Vector3];
 };
 
@@ -100,7 +107,9 @@ export type ObjectNetState = {
   scale: number;
   scaleTarget: number;
   startAt: number;
+  // Derived from GeometryResolver; not source of truth.
   targetCenter?: THREE.Vector3 | null;
+  // Derived from GeometryResolver; not source of truth.
   positionTarget?: THREE.Vector3 | null;
   preScaleDelay: number;
   postScaleDelay: number;

--- a/js/model/objectModelBuilder.ts
+++ b/js/model/objectModelBuilder.ts
@@ -10,6 +10,7 @@ import {
   type ObjectVertex
 } from './objectModel.js';
 
+// Derived geometry fields are resolved through GeometryResolver.
 const buildVertex = (vertex: StructureVertex, resolver: GeometryResolver): ObjectVertex | null => {
   const position = resolver.resolveVertex(vertex.id);
   if (!position) return null;


### PR DESCRIPTION
## 変更点\n- Object Model の派生情報（座標/法線/uvBasis/長さ）を明記\n- Resolver 起点の生成方針をコードに追記\n- 作業ログを更新\n\n## 理由\n- 座標を真実として保持せず、派生情報として整理するため\n\n## テスト\n- [ ] npm run typecheck\n- [ ] npm test\n\n## 影響/リスク\n- なし（挙動変更なし）\n\n## 関連Issue\n- Refs #10\n\n## 依存関係\n- Depends on なし\n