### PR TITLE
#11 [REF] Cutの交点/切断線をSnapPointID起点に整理

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -268,6 +268,14 @@ Summary:
 Notes:
 - Issue #10 の成果物として更新
 
+## 2026-01-19T11:36:20+09:00
+Summary:
+- Cutter の交点/切断線を SnapPointID 起点で扱い、座標を派生情報として整理
+- CutResult/Intersection 仕様に派生座標の扱いを追記
+
+Notes:
+- Issue #11 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/docs/specs/cutter/cut_result_schema.md
+++ b/docs/specs/cutter/cut_result_schema.md
@@ -20,16 +20,31 @@ interface IntersectionPoint {
   edgeId?: string;            // 交点が所属する EdgeID
   ratio?: { numerator: number; denominator: number };
   faceIds?: string[];         // 交点が属する面 (1-2 面)
-  position: THREE.Vector3;    // 描画用座標
+  position?: THREE.Vector3;   // 描画用座標（派生情報）
 }
 ```
 
 - `type='snap'` は入力点そのもの
 - `type='intersection'` は Edge と Plane の交点
+- `position` は SnapPointID から Resolver で再計算可能な派生情報
 
 ---
 
-## 3. Outline
+## 3. CutSegment
+
+```
+interface CutSegment {
+  startId: string;            // SnapPointID
+  endId: string;              // SnapPointID
+  faceIds?: string[];         // 共有面ID（展開図用）
+  start?: THREE.Vector3;      // 描画用座標（派生情報）
+  end?: THREE.Vector3;        // 描画用座標（派生情報）
+}
+```
+
+---
+
+## 4. Outline
 
 ```
 interface Outline {
@@ -39,7 +54,7 @@ interface Outline {
 
 ---
 
-## 4. CutResult
+## 5. CutResult
 
 ```
 interface CutResult {
@@ -47,26 +62,27 @@ interface CutResult {
   removedMesh: THREE.Mesh;     // 切り取られた部分
   outline: Outline;            // 切断面の輪郭
   intersections: IntersectionPoint[];
+  cutSegments: CutSegment[];
   markers: THREE.Mesh[];       // 教育用マーカー
 }
 ```
 
 ---
 
-## 5. 生成ルール
+## 6. 生成ルール
 - `intersections` には入力 SnapPoint も含める
 - `outline.points` は平面上の角度順でソート
 - `edgeId` と `ratio` は構造情報から決定
 
 ---
 
-## 6. 利用先
+## 7. 利用先
 - NetManager: faceIds に基づき 2D 投影
 - Explanation: id と ratio に基づき説明文生成
 - Verification: outline の点数と順序で形状判定
 
 ---
 
-## 7. まとめ
+## 8. まとめ
 - CutResult は構造情報を含む結果オブジェクト
 - 交点・輪郭線は再利用可能な教育資産となる

--- a/docs/specs/cutter/cutter_module_spec.md
+++ b/docs/specs/cutter/cutter_module_spec.md
@@ -46,7 +46,7 @@ Cutter.ts / Cutter.js の機能を TypeScript に分割する際の各モジュ�
 **主な関数 / メソッド**
 - `computeEdgeIntersections(plane: Plane, cube: Cube): IntersectionPoint[]`
     - 入力: Plane, Cube
-    - 出力: IntersectionPoint 配列（座標 + SnapPointID + 辺比率 + 所属面ID）
+    - 出力: IntersectionPoint 配列（SnapPointID + 辺比率 + 所属面ID + 派生座標）
 - `isPointOnSegment(p: Vector3, start: Vector3, end: Vector3, threshold?: number): boolean`
     - 距離ベースの線分判定（デフォルト threshold: 1e-5）
 
@@ -113,7 +113,7 @@ Cutter.ts / Cutter.js の機能を TypeScript に分割する際の各モジュ�
 
     interface SnapPoint {
         id: string; // SnapPointID
-        position: THREE.Vector3;
+        position?: THREE.Vector3; // 派生情報
         type: 'vertex' | 'edge' | 'face';
         edgeRatio?: { numerator: number; denominator: number }; // type='edge' の場合
         faceId?: string;    // 所属面ID

--- a/docs/specs/cutter/cutter_spec.md
+++ b/docs/specs/cutter/cutter_spec.md
@@ -76,6 +76,7 @@ Cutter モジュールは、3D立方体の切断処理を担当するコアコ�
 
 - Cutter 内部では座標（THREE.Vector3）ではなく **SnapPointID を基準** に処理を行う
 - Cube クラスに SnapPointID → THREE.Vector3 変換関数を用意
+- IntersectionPoint の座標は派生情報として Resolver 経由で再計算可能な扱いにする
 
     ```ts
     getSnapPointPosition(snapId: string): THREE.Vector3

--- a/docs/specs/cutter/intersection_calculator_spec.md
+++ b/docs/specs/cutter/intersection_calculator_spec.md
@@ -19,7 +19,7 @@ docs/specs/cutter/intersection_calculator_spec.md
 
     computeEdgeIntersections(plane: THREE.Plane, cube: Cube): IntersectionPoint[]
     - 入力: Plane, Cube
-    - 出力: IntersectionPoint 配列（座標 + SnapPointID + 辺比率 + 所属面ID）
+    - 出力: IntersectionPoint 配列（SnapPointID + 辺比率 + 所属面ID + 派生座標）
 
     isPointOnSegment(p: THREE.Vector3, start: THREE.Vector3, end: THREE.Vector3, threshold?: number): boolean
     - 入力: 点 p、線分 start–end
@@ -40,6 +40,7 @@ docs/specs/cutter/intersection_calculator_spec.md
     interface IntersectionPoint extends SnapPoint {
         edgeRatio: { numerator: number; denominator: number };  // 線分上の比率
         faceId?: string;    // 所属面ID
+        position?: THREE.Vector3; // 派生情報
     }
 
 ---

--- a/js/types.ts
+++ b/js/types.ts
@@ -34,6 +34,7 @@ export type IntersectionPoint = {
   edgeId?: string;
   ratio?: Ratio;
   faceIds?: string[];
+  // Derived via GeometryResolver; not source of truth.
   position?: unknown;
 };
 
@@ -61,7 +62,9 @@ export type CutResult = {
   cutSegments: Array<{
     startId: SnapPointID;
     endId: SnapPointID;
+    // Derived via GeometryResolver; not source of truth.
     start: unknown;
+    // Derived via GeometryResolver; not source of truth.
     end: unknown;
     faceIds?: string[];
   }>;


### PR DESCRIPTION
## 変更点\n- Cutter の切断線を ID メタデータ保持に変更し、座標は Resolver で都度解決\n- IntersectionPoint/CutSegment の派生座標の扱いを仕様・型で明記\n- 作業ログを更新\n\n## 理由\n- SnapPointID を真実として扱い、座標保持を派生情報に限定するため\n\n## テスト\n- [x] npm run typecheck\n- [x] npm test\n\n## 影響/リスク\n- Resolver が座標を解決できない場合、切断線が描画されない可能性\n\n## 関連Issue\n- Refs #11\n\n## 依存関係\n- Depends on なし\n