### PR TITLE
#12 [REF] Net展開のResolver起点化を強化

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -276,6 +276,14 @@ Summary:
 Notes:
 - Issue #11 の成果物として更新
 
+## 2026-01-19T12:19:58+09:00
+Summary:
+- Net 展開の切断線描画を Resolver 起点で解決するよう整理
+- Net マッピング仕様に SnapPointID 正の前提を追記
+
+Notes:
+- Issue #12 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/docs/specs/net/net_mapping_spec.md
+++ b/docs/specs/net/net_mapping_spec.md
@@ -17,6 +17,7 @@ Face / Edge / IntersectionPoint の構造情報から安定的に描画する。
 - GeometryResolver が face の basisU / basisV を提供する
 - 展開図描画は GeometryResolver を前提とし、座標ベースのフォールバックは使用しない
 - 展開図の対象は「切断後の残立体」に含まれる面集合とする
+- 切断線は `startId/endId` を正とし、座標は Resolver で都度解決する
 
 ---
 
@@ -54,6 +55,12 @@ interface NetMappingContext {
   offsetX: number;
   offsetY: number;
   layouts: FaceLayout[];
+}
+
+interface CutSegment {
+  startId: string;
+  endId: string;
+  faceIds?: string[];
 }
 ```
 

--- a/js/net/NetManager.ts
+++ b/js/net/NetManager.ts
@@ -134,10 +134,10 @@ export class NetManager {
     }
 
     // 切断線を描画
-    // cutSegments: Array of {startId, endId, start, end} (World座標系)
+    // cutSegments: Array of {startId, endId, start?, end?} (座標は派生情報)
     // cube: Cube instance (to get vertices and transform to local/face coords)
     /**
-     * @param {Array<{ startId: SnapPointID, endId: SnapPointID, start: THREE.Vector3, end: THREE.Vector3, faceIds?: string[], faceId?: string }>} cutSegments
+     * @param {Array<{ startId: SnapPointID, endId: SnapPointID, start?: THREE.Vector3, end?: THREE.Vector3, faceIds?: string[], faceId?: string }>} cutSegments
      * @param {object} cube
      * @param {object | null} resolver
      */
@@ -227,8 +227,11 @@ export class NetManager {
             if (!faceId) return;
             const face = faceIndex.get(faceId);
             if (!face) return;
-            const uv1 = this.map3Dto2D(segment.start, face, activeResolver);
-            const uv2 = this.map3Dto2D(segment.end, face, activeResolver);
+            const start = activeResolver.resolveSnapPoint(segment.startId);
+            const end = activeResolver.resolveSnapPoint(segment.endId);
+            if (!start || !end) return;
+            const uv1 = this.map3Dto2D(start, face, activeResolver);
+            const uv2 = this.map3Dto2D(end, face, activeResolver);
             if (!uv1 || !uv2) return;
             const ox = L.offsetX + face.grid.x * s;
             const oy = L.offsetY + face.grid.y * s;


### PR DESCRIPTION
## 変更点
- NetManager が切断線の始点/終点を SnapPointID から Resolver で解決するよう変更
- Net マッピング仕様に Resolver 起点の前提を追記
- 作業ログを更新

## 理由
- 座標保持に依存せず SnapPointID を真実として扱うため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- Resolver が座標を解決できない場合、切断線が描画されない可能性

## ロールバック
- NetManager の切断線解決を座標保持に戻す

## 関連Issue
- Fixes #12

## 依存関係
- Depends on なし
- [ ] なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
