### PR TITLE
#14 [TEST] Resolver 依存テストの追加

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -291,6 +291,13 @@ Summary:
 Notes:
 - Issue #13 の成果物として更新
 
+## 2026-01-19T12:36:36+09:00
+Summary:
+- Resolver 起点のテストを追加し、座標保持削減の回帰を防止
+
+Notes:
+- Issue #14 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/tests/unit/cutter_cut_point_markers.test.js
+++ b/tests/unit/cutter_cut_point_markers.test.js
@@ -15,4 +15,23 @@ describe('Cutter cut point markers', () => {
 
     expect(cutter.vertexMarkers.length).toBe(2);
   });
+
+  it('resolves marker positions via resolver when position is missing', () => {
+    const scene = new THREE.Scene();
+    const cutter = new Cutter(scene);
+    cutter.lastResolver = {
+      resolveSnapPoint: (id) => {
+        if (id === 'E:01@1/2') return new THREE.Vector3(0.5, 0, 0);
+        if (id === 'V:1') return new THREE.Vector3(1, 0, 0);
+        return null;
+      }
+    };
+
+    cutter.updateCutPointMarkers([
+      { id: 'E:01@1/2', type: 'intersection' },
+      { id: 'V:1', type: 'intersection' }
+    ]);
+
+    expect(cutter.vertexMarkers.length).toBe(2);
+  });
 });

--- a/tests/unit/net_manager.test.js
+++ b/tests/unit/net_manager.test.js
@@ -64,24 +64,23 @@ describe('NetManager', () => {
     const segment = {
       startId: 'E:01@1/2',
       endId: 'E:04@1/2',
-      start: resolver.resolveSnapPoint('E:01@1/2'),
-      end: resolver.resolveSnapPoint('E:04@1/2'),
       faceIds: ['F:0154']
     };
 
+    const resolveSpy = vi.spyOn(resolver, 'resolveSnapPoint');
     netManager.update([segment], cube, resolver);
 
     const ctx = netManager.ctx;
     expect(ctx.moveTo).toHaveBeenCalled();
     expect(ctx.lineTo).toHaveBeenCalled();
+    expect(resolveSpy).toHaveBeenCalledWith('E:01@1/2');
+    expect(resolveSpy).toHaveBeenCalledWith('E:04@1/2');
   });
 
   it('should draw segments inside the front face grid cell', () => {
     const segment = {
       startId: 'E:01@1/2',
       endId: 'E:04@1/2',
-      start: resolver.resolveSnapPoint('E:01@1/2'),
-      end: resolver.resolveSnapPoint('E:04@1/2'),
       faceIds: ['F:0154']
     };
 
@@ -102,8 +101,6 @@ describe('NetManager', () => {
     const segment = {
       startId: 'E:01@1/2',
       endId: 'E:04@1/2',
-      start: resolver.resolveSnapPoint('E:01@1/2'),
-      end: resolver.resolveSnapPoint('E:04@1/2'),
       faceIds: ['F:0154', 'F:0321']
     };
 

--- a/tests/unit/selection_manager.test.js
+++ b/tests/unit/selection_manager.test.js
@@ -22,4 +22,21 @@ describe('SelectionManager', () => {
     expect(manager.markers.length).toBe(2);
     expect(ui.updateSelectionCount).toHaveBeenCalledWith(1);
   });
+
+  it('should resolve selected point via resolver', () => {
+    const scene = new THREE.Scene();
+    const cube = { size: 10 };
+    const ui = { updateSelectionCount: vi.fn() };
+    const resolver = {
+      resolveSnapPoint: () => new THREE.Vector3(1, 2, 3)
+    };
+
+    const manager = new SelectionManager(scene, cube, ui, resolver);
+    manager.addPoint({ snapId: 'V:0' });
+
+    const point = manager.getSelectedPoint(0);
+    expect(point?.x).toBe(1);
+    expect(point?.y).toBe(2);
+    expect(point?.z).toBe(3);
+  });
 });


### PR DESCRIPTION
## 変更点
- Resolver 経由で座標を取得するテストを追加
- 既存テストから直接座標生成する記述を削除

## 理由
- 座標保持の撤廃を進めるため、Resolver 依存に寄せた回帰防止を強化する

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- テスト追加のみ

## ロールバック
- 追加したテストを削除

## 関連Issue
- Fixes #14

## 依存関係
- Depends on # (なし)
- [ ] # (なし)

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
