### PR TITLE
#36 [TEST] Model/Resolver 回帰テスト拡充

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -298,6 +298,13 @@ Summary:
 Notes:
 - Issue #14 の成果物として更新
 
+## 2026-01-19T13:02:11+09:00
+Summary:
+- Model/Resolver 依存のテストを追加し、派生座標の回帰を検知
+
+Notes:
+- Issue #36 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/tests/Cutter.test.js
+++ b/tests/Cutter.test.js
@@ -193,6 +193,24 @@ describe('Cutter', () => {
             });
         });
 
+        it('should resolve cut segments via resolver when positions are not stored', () => {
+            const resolveSnapPoint = vi.fn((id) => {
+                if (id === 'V:0') return new THREE.Vector3(0, 0, 0);
+                if (id === 'V:1') return new THREE.Vector3(1, 0, 0);
+                return null;
+            });
+            cutter.lastResolver = { resolveSnapPoint };
+            cutter.cutSegments = [{ startId: 'V:0', endId: 'V:1' }];
+
+            const segments = cutter.getCutSegments();
+
+            expect(resolveSnapPoint).toHaveBeenCalledWith('V:0');
+            expect(resolveSnapPoint).toHaveBeenCalledWith('V:1');
+            expect(segments.length).toBe(1);
+            expect(segments[0].start).toBeInstanceOf(THREE.Vector3);
+            expect(segments[0].end).toBeInstanceOf(THREE.Vector3);
+        });
+
         it('should form a closed outline loop from cut segments', () => {
             const snapIds = ['E:01@1/2', 'E:12@1/2', 'E:15@1/2'];
             const success = cutter.cut(cube, snapIds, resolver);


### PR DESCRIPTION
## 変更点
- Cutter の cutSegments が Resolver で位置解決されることをテスト化
- ObjectModelManager の交点解決が Resolver 必要時のみ呼ばれることをテスト化
- 移行作業ログを更新

## 理由
- 座標保持の撤廃に向けて Resolver 依存の回帰を防止するため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- テスト追加のみ

## ロールバック
- 追加したテストを削除

## 関連Issue
- Fixes #36

## 依存関係
- Depends on # (なし)
- [ ] # (なし)

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
