### PR TITLE
#43 [BUG] 展開図停止の根本修正

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -319,6 +319,13 @@ Summary:
 Notes:
 - Issue #43 の成果物として更新
 
+## 2026-01-19T13:57:34+09:00
+Summary:
+- prescale から opening への遷移が上書きされる問題を修正
+
+Notes:
+- Issue #43 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理


### PR DESCRIPTION
## 変更点
- prescale -> opening の遷移が上書きされないように状態更新を修正
- 展開停止の診断ログを整理し、必要最低限の異常値検出のみ残す
- 移行作業ログを更新

## 理由
- 展開図ボタン押下時に prescale が繰り返され停止する不具合の根本原因を解消するため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- net 展開の状態遷移が安定する

## ロールバック
- net 展開の状態更新修正を戻す

## 関連Issue
- Fixes #43

## 依存関係
- Depends on # (なし)
- [ ] # (なし)

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
