### PR TITLE
#37 [REF] ラベル表示のModel参照化（Phase A）

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -326,6 +326,13 @@ Summary:
 Notes:
 - Issue #43 の成果物として更新
 
+## 2026-01-19T14:07:55+09:00
+Summary:
+- ラベル表示を Model の display state 参照に統一
+
+Notes:
+- Issue #37 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/js/model/objectModelManager.ts
+++ b/js/model/objectModelManager.ts
@@ -137,6 +137,11 @@ export class ObjectModelManager {
     this.cube.toggleTransparency(display.cubeTransparent);
   }
 
+  getDisplayState() {
+    return (this.model ? this.model.display : null)
+      || (this.ui ? this.ui.getDisplayState() : DEFAULT_DISPLAY);
+  }
+
   applyTransparencyToView(displayOverride?: DisplayState) {
     const display = displayOverride
       || (this.model ? this.model.display : null)


### PR DESCRIPTION
## 変更点
- ラベル表示の参照元を ObjectModelManager の display state に統一
- net 展開ラベルの可視状態も Model に合わせる
- 移行作業ログを更新

## 理由
- ラベル表示の制御を Model 経由に一本化し、UI依存の分岐を減らすため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- 表示トグルの反映先が Model 基準になる

## ロールバック
- Model 参照の更新を戻す

## 関連Issue
- Fixes #37

## 依存関係
- Depends on # (なし)
- [ ] # (なし)

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
