### PR TITLE
#38 [REF] 立体メッシュ表示状態のModel集約（Phase B）

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -333,6 +333,13 @@ Summary:
 Notes:
 - Issue #37 の成果物として更新
 
+## 2026-01-19T14:15:40+09:00
+Summary:
+- 立体メッシュの透明/表示切替を Model の display state 参照に統一
+
+Notes:
+- Issue #38 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/main.ts
+++ b/main.ts
@@ -241,11 +241,12 @@ class App {
     }
 
     setInitialState() {
-        this.cutter.setTransparency(this.ui.isTransparencyChecked());
         const display = this.ui.getDisplayState();
         this.objectModelManager.setDisplay(display);
         this.objectModelManager.applyDisplayToView(display);
         this.objectModelManager.applyCutDisplayToView({ cutter: this.cutter });
+        const modelDisplay = this.objectModelManager.getDisplayState();
+        this.cutter.setTransparency(modelDisplay.cubeTransparent);
     }
 
     createUserPresetStorage() {
@@ -314,10 +315,9 @@ class App {
             this.selection.reset();
             return;
         }
-        this.cutter.toggleSurface(this.ui.isCutSurfaceChecked());
-        this.cutter.togglePyramid(this.ui.isPyramidChecked());
-        this.cutter.setCutPointsVisible(this.ui.isCutPointsChecked());
-        this.cutter.setCutLineColorize(this.ui.isCutLineColorChecked());
+        this.objectModelManager.applyCutDisplayToView({ cutter: this.cutter });
+        const modelDisplay = this.objectModelManager.getDisplayState();
+        this.cutter.setTransparency(modelDisplay.cubeTransparent);
         this.objectModelManager.syncCutState({
             intersections: this.cutter.getIntersectionRefs(),
             cutSegments: this.cutter.getCutSegments(),
@@ -843,12 +843,9 @@ class App {
             this.cameraTargetPosition = normal.clone().multiplyScalar(distance).add(offset.multiplyScalar(distance * 0.3));
             this.isCameraAnimating = true;
         }
-        this.cutter.toggleSurface(this.ui.isCutSurfaceChecked());
-        this.cutter.togglePyramid(this.ui.isPyramidChecked());
-        this.cutter.setTransparency(this.ui.isTransparencyChecked());
-        this.cutter.setCutPointsVisible(this.ui.isCutPointsChecked());
-        this.cutter.setCutLineColorize(this.ui.isCutLineColorChecked());
         const display = this.objectModelManager.getDisplayState();
+        this.objectModelManager.applyCutDisplayToView({ cutter: this.cutter });
+        this.cutter.setTransparency(display.cubeTransparent);
         this.selection.toggleVertexLabels(display.showVertexLabels);
     }
 
@@ -1079,10 +1076,9 @@ class App {
                 this.cube.setVertexLabelMap(this.currentLabelMap);
                 this.resolver.setLabelMap(this.currentLabelMap);
             }
-            this.objectModelManager.applyDisplayToView(this.ui.getDisplayState());
-            const isTrans = this.ui.isTransparencyChecked();
-            this.cube.toggleTransparency(isTrans);
-            this.cutter.setTransparency(isTrans);
+            const display = this.objectModelManager.getDisplayState();
+            this.objectModelManager.applyDisplayToView(display);
+            this.cutter.setTransparency(display.cubeTransparent);
         }
     }
 
@@ -1098,10 +1094,9 @@ class App {
             this.cube.setVertexLabelMap(this.currentLabelMap);
             this.resolver.setLabelMap(this.currentLabelMap);
         }
-        this.objectModelManager.applyDisplayToView(this.ui.getDisplayState());
-        const isTrans = this.ui.isTransparencyChecked();
-        this.cube.toggleTransparency(isTrans);
-        this.cutter.setTransparency(isTrans);
+        const display = this.objectModelManager.getDisplayState();
+        this.objectModelManager.applyDisplayToView(display);
+        this.cutter.setTransparency(display.cubeTransparent);
     }
 
     configureVertexLabelsFromReact(labels: string[]) {
@@ -1123,7 +1118,9 @@ class App {
         this.cube.setVertexLabelMap(labelMap);
         this.resolver.setLabelMap(labelMap);
         this.objectModelManager.syncFromCube();
-        this.objectModelManager.applyDisplayToView(this.ui.getDisplayState());
+        const display = this.objectModelManager.getDisplayState();
+        this.objectModelManager.applyDisplayToView(display);
+        this.cutter.setTransparency(display.cubeTransparent);
     }
 
     handleCancelUserPresetEdit() {
@@ -1828,7 +1825,7 @@ class App {
                     }
                 }
             });
-            const colorize = this.ui.isCutLineColorChecked();
+            const colorize = !!display.colorizeCutLines;
             edgeHighlightMeta.forEach((meta, edgeId) => {
                 const resolved = this.resolver.resolveEdge(edgeId);
                 const edge = structure.edgeMap.get(edgeId);
@@ -1853,7 +1850,7 @@ class App {
             });
         }
 
-        const cutPointsVisible = this.ui.isCutPointsChecked();
+        const cutPointsVisible = !!display.showCutPoints;
         const intersectionRefs = this.objectModelManager.resolveCutIntersectionPositions();
         intersectionRefs.forEach(ref => {
             const position = ref ? (ref.position as THREE.Vector3 | undefined) : undefined;
@@ -2059,10 +2056,9 @@ class App {
 
     handleFlipCutClick() {
         this.cutter.flipCut();
-        this.cutter.toggleSurface(this.ui.isCutSurfaceChecked());
-        this.cutter.togglePyramid(this.ui.isPyramidChecked());
-        this.cutter.setCutPointsVisible(this.ui.isCutPointsChecked());
-        this.cutter.setCutLineColorize(this.ui.isCutLineColorChecked());
+        this.objectModelManager.applyCutDisplayToView({ cutter: this.cutter });
+        const display = this.objectModelManager.getDisplayState();
+        this.cutter.setTransparency(display.cubeTransparent);
         this.objectModelManager.syncCutState({
             intersections: this.cutter.getIntersectionRefs(),
             cutSegments: this.cutter.getCutSegments(),
@@ -2165,8 +2161,9 @@ class App {
                 this.clearNetUnfoldGroup();
                 this.cube.setVisible(true);
                 this.cutter.setVisible(true);
-                this.cutter.toggleSurface(this.ui.isCutSurfaceChecked());
-                this.cutter.togglePyramid(this.ui.isPyramidChecked());
+                this.objectModelManager.applyCutDisplayToView({ cutter: this.cutter });
+                const display = this.objectModelManager.getDisplayState();
+                this.cutter.setTransparency(display.cubeTransparent);
                 this.controls.update();
             }
             if (netState.state !== 'closed') {


### PR DESCRIPTION
## 変更点
- 透明/表示切替の参照元を ObjectModelManager の display state に統一
- 展開/切断後の表示トグルも Model 基準で反映
- 移行作業ログを更新

## 理由
- 立体メッシュの表示状態を Model 起点に集約し、UI参照を減らすため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- 透明/切断表示の参照元が Model に変わる

## ロールバック
- Model 参照の更新を戻す

## 関連Issue
- Fixes #38

## 依存関係
- Depends on # (なし)
- [ ] # (なし)

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
