### PR TITLE
#39 [REF] Cutter補助表示のModel参照統一（Phase C）

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -340,6 +340,13 @@ Summary:
 Notes:
 - Issue #38 の成果物として更新
 
+## 2026-01-19T14:21:30+09:00
+Summary:
+- Cutter 補助表示の参照元を Model の display state に統一
+
+Notes:
+- Issue #39 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/main.ts
+++ b/main.ts
@@ -511,7 +511,7 @@ class App {
     }
 
     applyDisplayState(display = {}) {
-        const current = this.ui.getDisplayState();
+        const current = this.objectModelManager.getDisplayState();
         const next = { ...current, ...display };
         this.ui.applyDisplayState(next);
         this.objectModelManager.setDisplay(next);


### PR DESCRIPTION
## 変更点
- 表示状態の合成元を Model の display state に統一
- Cutter 補助表示の参照元を Model に寄せる
- 移行作業ログを更新

## 理由
- Cutter 補助表示（切断面/切断線）の制御を Model 起点に統一するため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- 表示トグルの適用順序が Model 基準になる

## ロールバック
- Model 参照の更新を戻す

## 関連Issue
- Fixes #39

## 依存関係
- Depends on # (なし)
- [ ] # (なし)

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
