### PR TITLE
#40 [REF] Net展開アニメ状態のModel同期（Phase D）

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -347,6 +347,13 @@ Summary:
 Notes:
 - Issue #39 の成果物として更新
 
+## 2026-01-19T14:32:22+09:00
+Summary:
+- Net 展開アニメの遷移パラメータを Model 起点で参照するよう統一
+
+Notes:
+- Issue #40 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/main.ts
+++ b/main.ts
@@ -1918,6 +1918,7 @@ class App {
         this.cameraTargetPosition = null;
         this.clearNetUnfoldGroup();
         this.buildNetUnfoldGroup();
+        const nextState = this.objectModelManager.getNetState();
         this.netUnfoldFaces.forEach(face => face.pivot.quaternion.copy(face.startQuat));
         const startAt = performance.now();
         this.cube.setVisible(false);
@@ -1938,18 +1939,21 @@ class App {
         this.updateNetOverlayDisplay(display);
         this.updateNetLabelDisplay(display);
         this.updateNetUnfoldScale();
+        const duration = nextState.duration || this.netUnfoldDuration;
+        const faceDuration = nextState.faceDuration || this.netUnfoldFaceDuration;
+        const stagger = nextState.stagger || this.netUnfoldStagger;
         this.setNetAnimationState({
             state: 'prescale',
             progress: 0,
-            duration: this.netUnfoldDuration,
-            faceDuration: this.netUnfoldFaceDuration,
-            stagger: this.netUnfoldStagger,
+            duration,
+            faceDuration,
+            stagger,
             scale: 1,
-            scaleTarget: this.objectModelManager.getNetState().scaleTarget,
-            targetCenter: this.objectModelManager.getNetState().targetCenter,
-            positionTarget: this.objectModelManager.getNetState().positionTarget,
-            preScaleDelay: this.netUnfoldPreScaleDelay,
-            postScaleDelay: this.netUnfoldPostScaleDelay,
+            scaleTarget: nextState.scaleTarget,
+            targetCenter: nextState.targetCenter,
+            positionTarget: nextState.positionTarget,
+            preScaleDelay: nextState.preScaleDelay,
+            postScaleDelay: nextState.postScaleDelay,
             startAt,
             camera
         });
@@ -1979,8 +1983,8 @@ class App {
             scaleTarget: netState.scaleTarget,
             targetCenter: netState.targetCenter,
             positionTarget: netState.positionTarget,
-            preScaleDelay: this.netUnfoldPreScaleDelay,
-            postScaleDelay: this.netUnfoldPostScaleDelay,
+            preScaleDelay: netState.preScaleDelay,
+            postScaleDelay: netState.postScaleDelay,
             startAt,
             camera
         });
@@ -2036,7 +2040,7 @@ class App {
                 nextState = 'open';
             } else {
                 nextState = 'postscale';
-                this.setNetAnimationState({ startAt: performance.now() + this.netUnfoldPostScaleDelay });
+                this.setNetAnimationState({ startAt: performance.now() + netState.postScaleDelay });
             }
         }
         this.setNetAnimationState({
@@ -2049,8 +2053,8 @@ class App {
             scaleTarget: nextState === 'postscale' ? 1 : netState.scaleTarget,
             targetCenter: netState.targetCenter,
             positionTarget: netState.positionTarget,
-            preScaleDelay: this.netUnfoldPreScaleDelay,
-            postScaleDelay: this.netUnfoldPostScaleDelay
+            preScaleDelay: netState.preScaleDelay,
+            postScaleDelay: netState.postScaleDelay
         });
     }
 
@@ -2147,7 +2151,7 @@ class App {
                     if (!this.netUnfoldScaleReadyAt) {
                         this.netUnfoldScaleReadyAt = performance.now();
                     }
-                    if (performance.now() - this.netUnfoldScaleReadyAt >= this.netUnfoldPreScaleDelay) {
+                    if (performance.now() - this.netUnfoldScaleReadyAt >= netState.preScaleDelay) {
                         this.netUnfoldScaleReadyAt = null;
                         const startAt = performance.now();
                         this.setNetAnimationState({ state: 'opening', progress: 0, startAt });
@@ -2177,8 +2181,8 @@ class App {
                     scaleTarget: netState.scaleTarget,
                     targetCenter: netState.targetCenter,
                     positionTarget: netState.positionTarget,
-                    preScaleDelay: this.netUnfoldPreScaleDelay,
-                    postScaleDelay: this.netUnfoldPostScaleDelay
+                    preScaleDelay: netState.preScaleDelay,
+                    postScaleDelay: netState.postScaleDelay
                 });
             }
         }


### PR DESCRIPTION
## 変更点
- Net 展開アニメの timing/delay を Model の net state 参照に統一
- 移行作業ログを更新

## 理由
- Net 展開アニメーションの状態を Model 起点に統一し、同期ズレを防ぐため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- net 展開アニメの参照元が Model になる

## ロールバック
- Model 参照の更新を戻す

## 関連Issue
- Fixes #40

## 依存関係
- Depends on # (なし)
- [ ] # (なし)

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
