### PR TITLE
#52 [BUG] 展開図の縮小を復元

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -354,6 +354,13 @@ Summary:
 Notes:
 - Issue #40 の成果物として更新
 
+## 2026-01-19T14:51:50+09:00
+Summary:
+- 展開図の縮小が効かない問題を修正し、scaleTarget を最新の Model から取得
+
+Notes:
+- Issue #52 の成果物として更新
+
 ## 2026-01-19T09:28:53+09:00
 Summary:
 - UIManager の legacy DOM 参照をフラグで抑制し、React UI 前提に整理

--- a/main.ts
+++ b/main.ts
@@ -1918,7 +1918,6 @@ class App {
         this.cameraTargetPosition = null;
         this.clearNetUnfoldGroup();
         this.buildNetUnfoldGroup();
-        const nextState = this.objectModelManager.getNetState();
         this.netUnfoldFaces.forEach(face => face.pivot.quaternion.copy(face.startQuat));
         const startAt = performance.now();
         this.cube.setVisible(false);
@@ -1939,6 +1938,7 @@ class App {
         this.updateNetOverlayDisplay(display);
         this.updateNetLabelDisplay(display);
         this.updateNetUnfoldScale();
+        const nextState = this.objectModelManager.getNetState();
         const duration = nextState.duration || this.netUnfoldDuration;
         const faceDuration = nextState.faceDuration || this.netUnfoldFaceDuration;
         const stagger = nextState.stagger || this.netUnfoldStagger;


### PR DESCRIPTION
## 変更点
- 展開図の縮小計算後に net state を再取得し、scaleTarget を最新化
- 移行作業ログを更新

## 理由
- 展開図が画面からはみ出す問題を解消するため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- 展開図のスケール適用順序が変わる

## ロールバック
- net state 再取得を戻す

## 関連Issue
- Fixes #52

## 依存関係
- Depends on # (なし)
- [ ] # (なし)

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
