### PR TITLE
#41 [REF] cut state from model strips coordinates

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -395,3 +395,11 @@ Summary:
 
 Notes:
 - count/tooltip/alert が無い環境でも例外を出さない
+
+## 2026-01-19T15:01:25+0900
+Summary:
+- ObjectModelManager が保持する切断情報から座標派生データを除去
+- cutSegments と faceAdjacency を ID ベースで正規化
+
+Notes:
+- IntersectionPoint の position や sharedEdge を保存せず、必要時に resolver で再計算

--- a/js/model/objectModel.ts
+++ b/js/model/objectModel.ts
@@ -65,9 +65,9 @@ export type ObjectCutSegment = {
   startId: SnapPointID;
   endId: SnapPointID;
   // Derived from GeometryResolver; not source of truth.
-  start: THREE.Vector3;
+  start?: THREE.Vector3;
   // Derived from GeometryResolver; not source of truth.
-  end: THREE.Vector3;
+  end?: THREE.Vector3;
   faceIds?: string[];
 };
 
@@ -75,7 +75,7 @@ export type ObjectCutAdjacency = {
   a: string;
   b: string;
   // Derived from GeometryResolver; not source of truth.
-  sharedEdge: [THREE.Vector3, THREE.Vector3];
+  sharedEdge?: [THREE.Vector3, THREE.Vector3];
 };
 
 export type ObjectCut = {

--- a/main.ts
+++ b/main.ts
@@ -1451,7 +1451,7 @@ class App {
         this.applyNetStateFromModel();
     }
 
-    buildCutNetUnfoldGroup(polygons: CutFacePolygon[], adjacency: Array<{ a: string; b: string; sharedEdge: [THREE.Vector3, THREE.Vector3] }>) {
+    buildCutNetUnfoldGroup(polygons: CutFacePolygon[], adjacency: Array<{ a: string; b: string }>) {
         const group = new THREE.Group();
         const faces = [];
         const display = this.objectModelManager.getDisplayState();

--- a/tests/unit/object_model_manager.test.js
+++ b/tests/unit/object_model_manager.test.js
@@ -99,7 +99,7 @@ describe('object model manager', () => {
     const vertexResolved = resolved.find(ref => ref.id === 'V:0');
 
     expect(resolveSpy).toHaveBeenCalledWith('E:01@1/2');
-    expect(resolveSpy).not.toHaveBeenCalledWith('V:0');
+    expect(resolveSpy).toHaveBeenCalledWith('V:0');
     expect(midpoint?.position).toBeInstanceOf(THREE.Vector3);
     expect(vertexResolved?.position).toBeInstanceOf(THREE.Vector3);
   });
@@ -129,9 +129,12 @@ describe('object model manager', () => {
 
     const model = manager.getModel();
     expect(model.cut.cutSegments.length).toBe(1);
+    expect(model.cut.cutSegments[0].start).toBeUndefined();
+    expect(model.cut.cutSegments[0].end).toBeUndefined();
     expect(manager.getCutSegments().length).toBe(1);
     expect(model.cut.facePolygons.length).toBe(1);
     expect(manager.getCutFaceAdjacency().length).toBe(1);
+    expect(manager.getCutFaceAdjacency()[0].sharedEdge).toBeUndefined();
   });
 
   it('syncs net state', () => {


### PR DESCRIPTION
## 変更点
- ObjectModelManager の cut 情報を ID ベースで正規化し、座標派生データを保存しない
- cut net の引数型を ID ベースの adjacency に合わせて緩和
- 位置解決のテストを resolver 前提に更新

## 理由
- 構造化モデルで座標保持を段階的に排除するため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- cut モデル内で position/sharedEdge を参照している処理がある場合は resolver で再計算が必要

## ロールバック
- 2e6c950 を revert

## 関連Issue
- Fixes #41

## 依存関係
- Depends on #なし
- [ ] #なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
