### PR TITLE
#58 [REF] Net state の座標派生値を排除

### DIFF
--- a/docs/architecture/object_model_spec.md
+++ b/docs/architecture/object_model_spec.md
@@ -63,7 +63,7 @@ Summary: アプリ全体を対象に、立体・切断・展開図の要素を�
 - `flattenedPolygons`: FaceID -> 2D polygon
 - `animationState`: { state, progress, timings }
 - `faces`: { faceId?, delayIndex }[]
-- `animation`: { state, progress, duration, faceDuration, stagger, scale, scaleTarget, startAt, targetCenter, positionTarget, preScaleDelay, postScaleDelay, camera }
+- `animation`: { state, progress, duration, faceDuration, stagger, scale, scaleTarget, startAt, preScaleDelay, postScaleDelay, camera }
 - `visible`: boolean (展開図UIの表示状態)
 
 ### DisplayState

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -60,7 +60,7 @@ Summary: 現行実装の把握と構造主体移行のための実装メモを�
 - Net 展開中の表示判定も Model の state を参照する
 - Net の progress は Model 起点で参照し、ローカル保持を削減する
 - Net の scale は Model 起点で参照し、ローカル保持を削減する
-- Net の targetCenter/positionTarget は Model 起点で参照し、ローカル保持を削減する
+- Net の targetCenter/positionTarget は View 側で都度算出し、Model には保持しない
 - Net の startAt/カメラ遷移は Model に保持し、描画で参照する
 - Net の表示状態（visible）は Model 起点で管理する
 - Net の UI 反映は __setNetVisible を介して Model の visible に同期する

--- a/docs/migration/coordinate_dependency_inventory.md
+++ b/docs/migration/coordinate_dependency_inventory.md
@@ -11,7 +11,7 @@ Summary: 座標依存箇所を棚卸しし、SnapPointID/Resolver 起点への�
 ## 依存分類
 ### A. 状態として座標を保持している
 - Object Model
-  - `js/model/objectModel.ts`: `ObjectVertex.position`, `ObjectFace.normal/uvBasis`, `ObjectCutSegment.start/end`, `ObjectNetState.targetCenter/positionTarget` など
+  - `js/model/objectModel.ts`: `ObjectVertex.position`, `ObjectFace.normal/uvBasis`, `ObjectCutSegment.start/end` など
   - `js/model/objectModelBuilder.ts`: Resolver で座標を構築してモデルに保持
 - main
   - `main.ts`: 展開図生成用の `cutFace.vertices` などが `THREE.Vector3` で保持される

--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -411,3 +411,10 @@ Summary:
 
 Notes:
 - 交点/切断線は resolver で再計算し、保持データは ID のみに統一
+
+## 2026-01-19T15:37:41+0900
+Summary:
+- Net state から targetCenter/positionTarget を削除し、View 側で都度計算するよう整理
+
+Notes:
+- モデルは進行状態のみ保持し、座標派生値は保持しない

--- a/js/model/objectModel.ts
+++ b/js/model/objectModel.ts
@@ -107,10 +107,6 @@ export type ObjectNetState = {
   scale: number;
   scaleTarget: number;
   startAt: number;
-  // Derived from GeometryResolver; not source of truth.
-  targetCenter?: THREE.Vector3 | null;
-  // Derived from GeometryResolver; not source of truth.
-  positionTarget?: THREE.Vector3 | null;
   preScaleDelay: number;
   postScaleDelay: number;
   camera?: {

--- a/js/model/objectModelManager.ts
+++ b/js/model/objectModelManager.ts
@@ -287,8 +287,6 @@ export class ObjectModelManager {
       scale: 1,
       scaleTarget: 1,
       startAt: 0,
-      targetCenter: null,
-      positionTarget: null,
       preScaleDelay: 0,
       postScaleDelay: 0,
       camera: {

--- a/main.ts
+++ b/main.ts
@@ -88,6 +88,8 @@ class App {
         delayIndex: number;
         faceId?: string;
     }>;
+    netUnfoldTargetCenter: THREE.Vector3 | null;
+    netUnfoldPositionTarget: THREE.Vector3 | null;
     netUnfoldPreScaleDelay: number;
     netUnfoldPostScaleDelay: number;
     netUnfoldScaleReadyAt: number | null;
@@ -121,6 +123,8 @@ class App {
         this.defaultCameraPosition = new THREE.Vector3(10, 5, 3);
         this.defaultCameraTarget = new THREE.Vector3(0, 0, 0);
         this.netUnfoldFaces = [];
+        this.netUnfoldTargetCenter = null;
+        this.netUnfoldPositionTarget = null;
         this.netUnfoldPreScaleDelay = 320;
         this.netUnfoldPostScaleDelay = 220;
         this.netUnfoldScaleReadyAt = null;
@@ -780,12 +784,10 @@ class App {
             });
             return;
         }
-        const targetCenter = center;
-        const positionTarget = new THREE.Vector3(-center.x, -center.y, 0);
+        this.netUnfoldTargetCenter = center.clone();
+        this.netUnfoldPositionTarget = new THREE.Vector3(-center.x, -center.y, 0);
         this.setNetAnimationState({
-            scaleTarget,
-            targetCenter,
-            positionTarget
+            scaleTarget
         });
     }
 
@@ -1409,8 +1411,6 @@ class App {
         scale?: number;
         scaleTarget?: number;
         startAt?: number;
-        targetCenter?: THREE.Vector3 | null;
-        positionTarget?: THREE.Vector3 | null;
         preScaleDelay?: number;
         postScaleDelay?: number;
         camera?: {
@@ -1445,8 +1445,6 @@ class App {
             scale: current.scale,
             scaleTarget: current.scaleTarget,
             startAt: current.startAt,
-            targetCenter: current.targetCenter ? current.targetCenter.clone() : null,
-            positionTarget: current.positionTarget ? current.positionTarget.clone() : null,
             preScaleDelay: this.netUnfoldPreScaleDelay,
             postScaleDelay: this.netUnfoldPostScaleDelay,
             camera: current.camera
@@ -1904,8 +1902,6 @@ class App {
         this.setNetAnimationState({
             state: 'closed',
             progress: 0,
-            targetCenter: null,
-            positionTarget: null,
             camera: {
                 startPos: null,
                 startTarget: null,
@@ -1913,6 +1909,8 @@ class App {
                 endTarget: null
             }
         });
+        this.netUnfoldTargetCenter = null;
+        this.netUnfoldPositionTarget = null;
     }
 
     startNetUnfold() {
@@ -1954,8 +1952,6 @@ class App {
             stagger,
             scale: 1,
             scaleTarget: nextState.scaleTarget,
-            targetCenter: nextState.targetCenter,
-            positionTarget: nextState.positionTarget,
             preScaleDelay: nextState.preScaleDelay,
             postScaleDelay: nextState.postScaleDelay,
             startAt,
@@ -1985,8 +1981,6 @@ class App {
             stagger: netState.stagger || this.netUnfoldStagger,
             scale: netState.scale,
             scaleTarget: netState.scaleTarget,
-            targetCenter: netState.targetCenter,
-            positionTarget: netState.positionTarget,
             preScaleDelay: netState.preScaleDelay,
             postScaleDelay: netState.postScaleDelay,
             startAt,
@@ -2055,8 +2049,6 @@ class App {
             stagger,
             scale: netState.scale,
             scaleTarget: nextState === 'postscale' ? 1 : netState.scaleTarget,
-            targetCenter: netState.targetCenter,
-            positionTarget: netState.positionTarget,
             preScaleDelay: netState.preScaleDelay,
             postScaleDelay: netState.postScaleDelay
         });
@@ -2138,8 +2130,8 @@ class App {
             if (netState.state === 'prescale') {
                 this.netUnfoldFaces.forEach(face => face.pivot.quaternion.copy(face.startQuat));
             }
-            if (netState.positionTarget) {
-                const target = netState.positionTarget;
+            if (this.netUnfoldPositionTarget) {
+                const target = this.netUnfoldPositionTarget;
                 const scale = nextScale;
                 const scaledTarget = new THREE.Vector3(target.x * scale, target.y * scale, 0);
                 if (netState.state === 'postscale') {
@@ -2183,8 +2175,6 @@ class App {
             stagger: netState.stagger,
                     scale: nextScale,
                     scaleTarget: netState.scaleTarget,
-                    targetCenter: netState.targetCenter,
-                    positionTarget: netState.positionTarget,
                     preScaleDelay: netState.preScaleDelay,
                     postScaleDelay: netState.postScaleDelay
                 });


### PR DESCRIPTION
## 変更点
- ObjectNetState から targetCenter/positionTarget を削除
- Net 展開の位置ターゲットは View 側で都度計算する形へ整理
- 仕様/移行メモの更新

## 理由
- Net state に座標派生値を保持しない方針に合わせるため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- Net 展開位置は View 側の再計算に依存

## ロールバック
- fc7850f を revert

## 関連Issue
- Fixes #58

## 依存関係
- Depends on #なし
- [ ] #なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
