### PR TITLE
#59 [REF] 展開図生成の座標依存を解消

### DIFF
--- a/docs/migration/coordinate_dependency_inventory.md
+++ b/docs/migration/coordinate_dependency_inventory.md
@@ -14,7 +14,7 @@ Summary: 座標依存箇所を棚卸しし、SnapPointID/Resolver 起点への�
   - `js/model/objectModel.ts`: `ObjectVertex.position`, `ObjectFace.normal/uvBasis`, `ObjectCutSegment.start/end` など
   - `js/model/objectModelBuilder.ts`: Resolver で座標を構築してモデルに保持
 - main
-  - `main.ts`: 展開図生成用の `cutFace.vertices` などが `THREE.Vector3` で保持される
+  - `main.ts`: 展開図生成は SnapPointID を resolver で解決し、座標保持への依存を減らす
 
 ### B. 描画時に Resolver で都度解決
 - Selection/Interaction

--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -418,3 +418,11 @@ Summary:
 
 Notes:
 - モデルは進行状態のみ保持し、座標派生値は保持しない
+
+## 2026-01-19T15:45:25+0900
+Summary:
+- 展開図生成で cutFace.vertices 依存を避け、SnapPointID から resolver で再計算するよう整理
+- CutFacePolygon に vertexIds を持たせ、ID 参照の描画経路を追加
+
+Notes:
+- vertexIds が解決できない場合は既存 vertices をフォールバック

--- a/js/types.ts
+++ b/js/types.ts
@@ -74,6 +74,7 @@ export type CutFacePolygon = {
   faceId: string;
   type: 'cut' | 'original';
   vertices: unknown[];
+  vertexIds?: SnapPointID[];
   normal?: unknown;
   sourceFaceId?: string;
 };


### PR DESCRIPTION
## 変更点
- CutFacePolygon の頂点を SnapPointID で解決し、展開図メッシュ生成を resolver 起点に変更
- CutFacePolygon に vertexIds を追加し、IDベースの描画経路を用意
- 座標依存棚卸しの更新

## 理由
- 展開図生成の座標依存を減らし、ID/Resolver 起点に寄せるため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- vertexIds が解決できない場合は既存 vertices へフォールバック

## ロールバック
- cedb804 を revert

## 関連Issue
- Fixes #59

## 依存関係
- Depends on #なし
- [ ] #なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
