### PR TITLE
#56 [REF] ObjectModel solid 派生座標の排除

### DIFF
--- a/docs/architecture/object_model_spec.md
+++ b/docs/architecture/object_model_spec.md
@@ -15,13 +15,12 @@ Summary: アプリ全体を対象に、立体・切断・展開図の要素を�
 ## 派生情報の扱い
 - `position` / `normal` / `uvBasis` / `length` などの幾何値は派生情報として扱う。
 - 真実は SnapPointID と構造モデルに置き、派生情報は再計算可能であることを前提にする。
-- 移行完了後は派生情報をモデルから除去できる状態を目指す。
+- Solid から派生情報を排除し、必要時に resolver で解決する。
 
 ## モデル構成（最小）
 
 ### Vertex
 - `id`: VertexID (例: `V:0`)
-- `position`: THREE.Vector3 (派生情報としてのワールド座標)
 - `label`: string (表示ラベル)
 - `flags`: { selected, hovered, isCutPoint, isSnapPoint }
 
@@ -29,7 +28,6 @@ Summary: アプリ全体を対象に、立体・切断・展開図の要素を�
 - `id`: EdgeID (例: `E:01`)
 - `v1`, `v2`: Vertex 参照
 - `faces`: FaceID[]
-- `length`: number (派生情報)
 - `flags`: { selected, hovered, isCutEdge, hasCutPoint, isMidpointCut }
   - `hasCutPoint` / `isMidpointCut` は切断線の色分け判定に利用
 
@@ -37,8 +35,6 @@ Summary: アプリ全体を対象に、立体・切断・展開図の要素を�
 - `id`: FaceID (例: `F:0154`)
 - `vertices`: Vertex[]
 - `edges`: Edge[]
-- `normal`: THREE.Vector3 (派生情報)
-- `uvBasis`: { origin: THREE.Vector3, u: THREE.Vector3, v: THREE.Vector3 } (派生情報)
 - `flags`: { selected, hovered, isCutFace, isOriginalFace }
 - `polygons`: FacePolygon[] (切断後の分割面)
 

--- a/docs/migration/coordinate_dependency_inventory.md
+++ b/docs/migration/coordinate_dependency_inventory.md
@@ -10,9 +10,9 @@ Summary: 座標依存箇所を棚卸しし、SnapPointID/Resolver 起点への�
 
 ## 依存分類
 ### A. 状態として座標を保持している
-- Object Model
-  - `js/model/objectModel.ts`: `ObjectVertex.position`, `ObjectFace.normal/uvBasis`, `ObjectCutSegment.start/end` など
-  - `js/model/objectModelBuilder.ts`: Resolver で座標を構築してモデルに保持
+- Cut Result
+  - `js/types.ts`: `CutFacePolygon.vertices` が座標配列を保持
+  - `js/cutter/cutFaceExtractor.ts`: メッシュから座標ベースでポリゴンを抽出
 - main
   - `main.ts`: 展開図生成は SnapPointID を resolver で解決し、座標保持への依存を減らす
 
@@ -36,16 +36,16 @@ Summary: 座標依存箇所を棚卸しし、SnapPointID/Resolver 起点への�
   - 交点/切断線の計算結果に座標が含まれる
 - `js/net/NetManager.ts`
   - 面投影で Resolver を利用しつつも座標配列を扱う
-- `js/model/*`
-  - モデルが座標を保持する設計
+- `js/cutter/cutFaceExtractor.ts`
+  - 切断後ポリゴン生成が座標ベース
 
 ## 移行優先度（提案）
 1) Cut/交点/切断線の保持を SnapPointID 起点に整理
    - `IntersectionPoint.position` や `cutSegments.start/end` を派生情報へ寄せる
 2) Net 展開の投影/面同定を Resolver 起点に統一
    - 面/辺の同定に座標フォールバックを持たない構成へ
-3) Object Model の座標保持を段階的に削減
-   - `ObjectVertex.position` などを派生情報扱いにして最終的に削除
+3) CutFacePolygon の頂点保持を SnapPointID 起点へ移行
+   - `CutFacePolygon.vertices` を削除できる状態へ寄せる
 
 ## 次のアクション
 - Issue #10/#11/#12/#13 の順に詳細移行計画へ落とし込む

--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -426,3 +426,11 @@ Summary:
 
 Notes:
 - vertexIds が解決できない場合は既存 vertices をフォールバック
+
+## 2026-01-19T15:52:12+0900
+Summary:
+- ObjectModel の solid から派生座標（position/normal/uvBasis/length）を削除
+- ObjectModelBuilder とテストを ID/構造参照のみへ更新
+
+Notes:
+- 座標派生値は resolver で都度解決する方針

--- a/js/model/objectModel.ts
+++ b/js/model/objectModel.ts
@@ -27,8 +27,6 @@ export type ObjectVertex = {
   id: string;
   index: number;
   label: string | null;
-  // Derived from GeometryResolver; not source of truth.
-  position: THREE.Vector3;
   flags: ObjectVertexFlags;
 };
 
@@ -36,8 +34,6 @@ export type ObjectEdge = {
   id: string;
   vertices: [ObjectVertex, ObjectVertex];
   faces: string[];
-  // Derived from GeometryResolver; not source of truth.
-  length: number;
   flags: ObjectEdgeFlags;
 };
 
@@ -45,10 +41,6 @@ export type ObjectFace = {
   id: string;
   vertices: ObjectVertex[];
   edges: ObjectEdge[];
-  // Derived from GeometryResolver; not source of truth.
-  normal: THREE.Vector3;
-  // Derived from GeometryResolver; not source of truth.
-  uvBasis: { origin: THREE.Vector3; u: THREE.Vector3; v: THREE.Vector3 };
   flags: ObjectFaceFlags;
   polygons: unknown[];
 };

--- a/js/model/objectModelBuilder.ts
+++ b/js/model/objectModelBuilder.ts
@@ -10,34 +10,26 @@ import {
   type ObjectVertex
 } from './objectModel.js';
 
-// Derived geometry fields are resolved through GeometryResolver.
-const buildVertex = (vertex: StructureVertex, resolver: GeometryResolver): ObjectVertex | null => {
-  const position = resolver.resolveVertex(vertex.id);
-  if (!position) return null;
+const buildVertex = (vertex: StructureVertex): ObjectVertex => {
   return {
     id: vertex.id,
     index: vertex.index,
     label: vertex.label || null,
-    position,
     flags: createDefaultVertexFlags()
   };
 };
 
 const buildEdge = (
   edge: StructureEdge,
-  vertexMap: Map<string, ObjectVertex>,
-  resolver: GeometryResolver
+  vertexMap: Map<string, ObjectVertex>
 ): ObjectEdge | null => {
   const v1 = vertexMap.get(edge.vertices[0]);
   const v2 = vertexMap.get(edge.vertices[1]);
   if (!v1 || !v2) return null;
-  const resolved = resolver.resolveEdge(edge.id);
-  if (!resolved) return null;
   return {
     id: edge.id,
     vertices: [v1, v2],
     faces: edge.faces.slice(),
-    length: resolved.length,
     flags: createDefaultEdgeFlags()
   };
 };
@@ -45,11 +37,8 @@ const buildEdge = (
 const buildFace = (
   face: StructureFace,
   vertexMap: Map<string, ObjectVertex>,
-  edgeMap: Map<string, ObjectEdge>,
-  resolver: GeometryResolver
+  edgeMap: Map<string, ObjectEdge>
 ): ObjectFace | null => {
-  const resolved = resolver.resolveFace(face.id);
-  if (!resolved) return null;
   const vertices = face.vertices
     .map(id => vertexMap.get(id))
     .filter((vertex): vertex is ObjectVertex => !!vertex);
@@ -61,12 +50,6 @@ const buildFace = (
     id: face.id,
     vertices,
     edges,
-    normal: resolved.normal.clone(),
-    uvBasis: {
-      origin: resolved.vertices[0].clone(),
-      u: resolved.basisU.clone(),
-      v: resolved.basisV.clone()
-    },
     flags: createDefaultFaceFlags(),
     polygons: []
   };
@@ -89,17 +72,16 @@ export const buildObjectSolidModel = ({
 }): ObjectSolid | null => {
   if (!structure || !resolver) return null;
   const vertices = structure.vertices
-    .map(vertex => buildVertex(vertex, resolver))
-    .filter((vertex): vertex is ObjectVertex => !!vertex);
+    .map(vertex => buildVertex(vertex));
   if (!vertices.length) return null;
 
   const vertexMap = new Map(vertices.map(vertex => [vertex.id, vertex]));
   const edges = structure.edges
-    .map(edge => buildEdge(edge, vertexMap, resolver))
+    .map(edge => buildEdge(edge, vertexMap))
     .filter((edge): edge is ObjectEdge => !!edge);
   const edgeMap = new Map(edges.map(edge => [edge.id, edge]));
   const faces = structure.faces
-    .map(face => buildFace(face, vertexMap, edgeMap, resolver))
+    .map(face => buildFace(face, vertexMap, edgeMap))
     .filter((face): face is ObjectFace => !!face);
 
   return {

--- a/tests/unit/object_model_builder.test.js
+++ b/tests/unit/object_model_builder.test.js
@@ -29,15 +29,15 @@ describe('object model builder', () => {
 
     const v0 = model.vertices.find(vertex => vertex.id === 'V:0');
     expect(v0).toBeTruthy();
-    expect(v0.position).toBeInstanceOf(THREE.Vector3);
+    expect(v0.position).toBeUndefined();
 
     const edge = model.edges.find(e => e.id === 'E:01');
     expect(edge).toBeTruthy();
-    expect(edge.length).toBeGreaterThan(0);
+    expect(edge.length).toBeUndefined();
 
     const face = model.faces.find(f => f.id === 'F:0154');
     expect(face).toBeTruthy();
     expect(face.vertices).toHaveLength(4);
-    expect(face.normal).toBeInstanceOf(THREE.Vector3);
+    expect(face.normal).toBeUndefined();
   });
 });


### PR DESCRIPTION
## 変更点
- ObjectModel solid から position/normal/uvBasis/length を削除
- ObjectModelBuilder を ID/構造参照のみの生成に変更
- 仕様/棚卸し/テストを更新

## 理由
- Solid の派生座標を保持せず resolver 起点に統一するため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- Solid 内の派生座標参照は resolver 経由へ寄せる必要がある

## ロールバック
- 357f985 を revert

## 関連Issue
- Fixes #56

## 依存関係
- Depends on #なし
- [ ] #なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
