### PR TITLE
#57 [REF] Cut face polygons の座標保持を排除

### DIFF
--- a/docs/migration/coordinate_dependency_inventory.md
+++ b/docs/migration/coordinate_dependency_inventory.md
@@ -11,7 +11,6 @@ Summary: 座標依存箇所を棚卸しし、SnapPointID/Resolver 起点への�
 ## 依存分類
 ### A. 状態として座標を保持している
 - Cut Result
-  - `js/types.ts`: `CutFacePolygon.vertices` が座標配列を保持
   - `js/cutter/cutFaceExtractor.ts`: メッシュから座標ベースでポリゴンを抽出
 - main
   - `main.ts`: 展開図生成は SnapPointID を resolver で解決し、座標保持への依存を減らす
@@ -22,6 +21,7 @@ Summary: 座標依存箇所を棚卸しし、SnapPointID/Resolver 起点への�
   - `js/SelectionManager.ts`: SnapPointID から `resolveEdge/resolveSnapPoint` を使いラベル位置を計算
 - Cutter
   - `js/Cutter.ts`: 交点/切断線は SnapPointID を保持し、座標は resolver で都度解決
+  - `js/Cutter.ts`: CutFacePolygon は vertexIds を保持し、座標は resolver で都度解決
 - Net
   - `js/net/NetManager.ts`: faceId から `resolver.resolveFace/resolveVertex` を使って投影
 

--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -434,3 +434,11 @@ Summary:
 
 Notes:
 - 座標派生値は resolver で都度解決する方針
+
+## 2026-01-19T16:02:40+0900
+Summary:
+- CutFacePolygon の vertexIds を resolver で解決する経路を追加し、座標保持を削減
+- Face adjacency を vertexIds 優先で構築するよう更新
+
+Notes:
+- vertexIds 解決失敗時は vertices をフォールバック

--- a/js/cutter/cutFaceGraph.ts
+++ b/js/cutter/cutFaceGraph.ts
@@ -1,10 +1,10 @@
 import * as THREE from 'three';
-import type { CutFacePolygon } from '../types.js';
+import type { CutFacePolygon, SnapPointID } from '../types.js';
 
 type Adjacency = {
   a: string;
   b: string;
-  sharedEdge: [THREE.Vector3, THREE.Vector3];
+  sharedEdgeIds?: [SnapPointID, SnapPointID];
 };
 
 const defaultEpsilon = 1e-3;
@@ -15,30 +15,38 @@ const makeVertexKey = (v: THREE.Vector3, epsilon: number) =>
   `${makeKey(v.x, epsilon)}|${makeKey(v.y, epsilon)}|${makeKey(v.z, epsilon)}`;
 
 export const buildFaceAdjacency = (polygons: CutFacePolygon[], epsilon = defaultEpsilon): Adjacency[] => {
-  const edgeMap = new Map<string, { faceId: string; edge: [THREE.Vector3, THREE.Vector3] }>();
+  const edgeMap = new Map<string, { faceId: string; edgeIds?: [SnapPointID, SnapPointID]; edge?: [THREE.Vector3, THREE.Vector3] }>();
   const adjacency: Adjacency[] = [];
 
   polygons.forEach(polygon => {
     const faceId = polygon.faceId;
+    const vertexIds = Array.isArray(polygon.vertexIds) ? polygon.vertexIds : [];
     const vertices = (polygon.vertices || []) as THREE.Vector3[];
-    if (!faceId || vertices.length < 2) return;
-    for (let i = 0; i < vertices.length; i++) {
-      const start = vertices[i];
-      const end = vertices[(i + 1) % vertices.length];
-      if (!(start instanceof THREE.Vector3) || !(end instanceof THREE.Vector3)) continue;
-      const startKey = makeVertexKey(start, epsilon);
-      const endKey = makeVertexKey(end, epsilon);
+    if (!faceId || (vertexIds.length < 2 && vertices.length < 2)) return;
+    const total = vertexIds.length || vertices.length;
+    for (let i = 0; i < total; i++) {
+      const startId = vertexIds.length ? vertexIds[i] : null;
+      const endId = vertexIds.length ? vertexIds[(i + 1) % vertexIds.length] : null;
+      const start = vertexIds.length ? null : vertices[i];
+      const end = vertexIds.length ? null : vertices[(i + 1) % vertices.length];
+      if (!startId && (!(start instanceof THREE.Vector3) || !(end instanceof THREE.Vector3))) continue;
+      const startKey = startId ? startId : makeVertexKey(start, epsilon);
+      const endKey = endId ? endId : makeVertexKey(end, epsilon);
       const edgeKey = startKey < endKey ? `${startKey}|${endKey}` : `${endKey}|${startKey}`;
       const existing = edgeMap.get(edgeKey);
       if (!existing) {
-        edgeMap.set(edgeKey, { faceId, edge: [start.clone(), end.clone()] });
+        edgeMap.set(edgeKey, {
+          faceId,
+          edgeIds: startId && endId ? [startId, endId] : undefined,
+          edge: start && end ? [start.clone(), end.clone()] : undefined
+        });
         continue;
       }
       if (existing.faceId !== faceId) {
         adjacency.push({
           a: existing.faceId,
           b: faceId,
-          sharedEdge: existing.edge
+          sharedEdgeIds: existing.edgeIds
         });
       }
     }

--- a/js/types.ts
+++ b/js/types.ts
@@ -73,7 +73,7 @@ export type CutResult = {
 export type CutFacePolygon = {
   faceId: string;
   type: 'cut' | 'original';
-  vertices: unknown[];
+  vertices?: unknown[];
   vertexIds?: SnapPointID[];
   normal?: unknown;
   sourceFaceId?: string;


### PR DESCRIPTION
## 変更点
- CutFacePolygon の頂点を SnapPointID で解決し、座標保持を削減
- Face adjacency を vertexIds 優先で構築
- CutFacePolygon の vertices を optional に変更

## 理由
- cut face polygons の座標保持を排除し、resolver 起点に寄せるため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- vertexIds 解決失敗時は vertices にフォールバック

## ロールバック
- 8fdae0b を revert

## 関連Issue
- Fixes #57

## 依存関係
- Depends on #なし
- [ ] #なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
