### PR TITLE
#64 [BUG] 展開後の頂点/面ラベル表示が反映されない

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1238,6 +1238,7 @@ class App {
         const addFaceLabels = (mesh: THREE.Mesh, width: number, height: number, faceName: string, vertexIndices: number[]) => {
             const faceLabel = createLabel(faceName, this.cube.size / 10, 'rgba(0,0,0,0.6)');
             faceLabel.position.set(0, 0, 0.06);
+            faceLabel.userData.type = 'net-face-label';
             faceLabel.visible = !!display.showFaceLabels;
             mesh.add(faceLabel);
             const corners = [
@@ -1251,6 +1252,7 @@ class App {
                 if (!label) return;
                 const sprite = createLabel(label, this.cube.size / 14, 'rgba(0,0,0,0.75)');
                 sprite.position.copy(corners[idx] || corners[0]);
+                sprite.userData.type = 'net-vertex-label';
                 sprite.visible = !!display.showVertexLabels;
                 mesh.add(sprite);
             });


### PR DESCRIPTION
## 変更点
- 展開図用の面/頂点ラベルに userData.type を付与し、表示トグルの対象に含める

## 理由
- 展開後にラベル表示トグルが反映されない不具合を修正するため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- 既存のラベル表示初期状態には影響なし

## ロールバック
- 2adec23 を revert

## 関連Issue
- Fixes #64

## 依存関係
- Depends on #なし
- [ ] #なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [ ] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
