### PR TITLE
#72 [REF] CutFacePolygon の座標フォールバック排除

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -442,3 +442,11 @@ Summary:
 
 Notes:
 - vertexIds 解決失敗時は vertices をフォールバック
+
+## 2026-01-19T17:43:00+0900
+Summary:
+- CutFacePolygon の vertices フォールバックを排除し、vertexIds のみを保持
+- Face adjacency も vertexIds 前提に統一
+
+Notes:
+- vertexIds を解決できないポリゴンは除外し、座標保持を禁止

--- a/js/Cutter.ts
+++ b/js/Cutter.ts
@@ -846,18 +846,15 @@ export class Cutter {
                   vertexCount: vertices.length,
                   resolved: vertexIds.length
               });
-              return {
-                  ...polygon,
-                  vertexIds: vertexIds.length ? vertexIds : undefined
-              };
+              return null;
           }
           return {
               ...polygon,
-              vertices: [],
+              vertices: undefined,
               vertexIds,
               normal: undefined
           };
-      });
+      }).filter(Boolean);
   }
 
   /** @returns {Array<{ a: string; b: string; sharedEdge: [THREE.Vector3, THREE.Vector3] }>} */

--- a/js/cutter/cutFaceGraph.ts
+++ b/js/cutter/cutFaceGraph.ts
@@ -1,4 +1,3 @@
-import * as THREE from 'three';
 import type { CutFacePolygon, SnapPointID } from '../types.js';
 
 type Adjacency = {
@@ -7,38 +6,24 @@ type Adjacency = {
   sharedEdgeIds?: [SnapPointID, SnapPointID];
 };
 
-const defaultEpsilon = 1e-3;
-
-const makeKey = (value: number, epsilon: number) => Math.round(value / epsilon).toString(10);
-
-const makeVertexKey = (v: THREE.Vector3, epsilon: number) =>
-  `${makeKey(v.x, epsilon)}|${makeKey(v.y, epsilon)}|${makeKey(v.z, epsilon)}`;
-
-export const buildFaceAdjacency = (polygons: CutFacePolygon[], epsilon = defaultEpsilon): Adjacency[] => {
-  const edgeMap = new Map<string, { faceId: string; edgeIds?: [SnapPointID, SnapPointID]; edge?: [THREE.Vector3, THREE.Vector3] }>();
+export const buildFaceAdjacency = (polygons: CutFacePolygon[]): Adjacency[] => {
+  const edgeMap = new Map<string, { faceId: string; edgeIds?: [SnapPointID, SnapPointID] }>();
   const adjacency: Adjacency[] = [];
 
   polygons.forEach(polygon => {
     const faceId = polygon.faceId;
     const vertexIds = Array.isArray(polygon.vertexIds) ? polygon.vertexIds : [];
-    const vertices = (polygon.vertices || []) as THREE.Vector3[];
-    if (!faceId || (vertexIds.length < 2 && vertices.length < 2)) return;
-    const total = vertexIds.length || vertices.length;
-    for (let i = 0; i < total; i++) {
-      const startId = vertexIds.length ? vertexIds[i] : null;
-      const endId = vertexIds.length ? vertexIds[(i + 1) % vertexIds.length] : null;
-      const start = vertexIds.length ? null : vertices[i];
-      const end = vertexIds.length ? null : vertices[(i + 1) % vertices.length];
-      if (!startId && (!(start instanceof THREE.Vector3) || !(end instanceof THREE.Vector3))) continue;
-      const startKey = startId ? startId : makeVertexKey(start, epsilon);
-      const endKey = endId ? endId : makeVertexKey(end, epsilon);
-      const edgeKey = startKey < endKey ? `${startKey}|${endKey}` : `${endKey}|${startKey}`;
+    if (!faceId || vertexIds.length < 2) return;
+    for (let i = 0; i < vertexIds.length; i++) {
+      const startId = vertexIds[i];
+      const endId = vertexIds[(i + 1) % vertexIds.length];
+      if (!startId || !endId) continue;
+      const edgeKey = startId < endId ? `${startId}|${endId}` : `${endId}|${startId}`;
       const existing = edgeMap.get(edgeKey);
       if (!existing) {
         edgeMap.set(edgeKey, {
           faceId,
           edgeIds: startId && endId ? [startId, endId] : undefined,
-          edge: start && end ? [start.clone(), end.clone()] : undefined
         });
         continue;
       }

--- a/main.ts
+++ b/main.ts
@@ -1529,16 +1529,12 @@ class App {
 
         const resolvePolygonVertices = (face: CutFacePolygon) => {
             const ids = getPolygonVertexIds(face);
-            if (ids.length) {
-                const resolved = ids
-                    .map(id => this.resolver.resolveSnapPoint(id))
-                    .filter((pos): pos is THREE.Vector3 => pos instanceof THREE.Vector3);
-                if (resolved.length === ids.length) return resolved;
-            }
-            const verts = face.vertices as THREE.Vector3[];
-            return Array.isArray(verts)
-                ? verts.filter((pos): pos is THREE.Vector3 => pos instanceof THREE.Vector3).map(pos => pos.clone())
-                : [];
+            if (!ids.length) return [];
+            const resolved = ids
+                .map(id => this.resolver.resolveSnapPoint(id))
+                .filter((pos): pos is THREE.Vector3 => pos instanceof THREE.Vector3);
+            if (resolved.length === ids.length) return resolved;
+            return [];
         };
 
         const computeNormal = (face: CutFacePolygon) => {

--- a/tests/unit/cut_face_graph.test.js
+++ b/tests/unit/cut_face_graph.test.js
@@ -1,20 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import * as THREE from 'three';
 import { buildFaceAdjacency } from '../../dist/js/cutter/cutFaceGraph.js';
-
-const v = (x, y, z) => new THREE.Vector3(x, y, z);
 
 describe('buildFaceAdjacency', () => {
   it('should detect shared edge between two faces', () => {
     const faceA = {
       faceId: 'F:A',
       type: 'original',
-      vertices: [v(0, 0, 0), v(1, 0, 0), v(1, 1, 0), v(0, 1, 0)]
+      vertexIds: ['V:0', 'V:1', 'V:2', 'V:3']
     };
     const faceB = {
       faceId: 'F:B',
       type: 'original',
-      vertices: [v(1, 0, 0), v(2, 0, 0), v(2, 1, 0), v(1, 1, 0)]
+      vertexIds: ['V:1', 'V:4', 'V:5', 'V:2']
     };
 
     const adjacency = buildFaceAdjacency([faceA, faceB]);


### PR DESCRIPTION
## 変更点
- CutFacePolygon を vertexIds のみで扱い、座標フォールバックを削除
- Face adjacency を ID 前提に統一
- 展開図生成の頂点解決は ID 完全一致のみ許可

## 理由
- CutFacePolygon の座標保持を完全排除するため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- vertexIds を解決できないポリゴンは除外される

## ロールバック
- ef4563d を revert

## 関連Issue
- Fixes #72

## 依存関係
- Depends on #なし
- [ ] #なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
