### PR TITLE
#84 [REF] drop cut coordinate helper APIs

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -473,3 +473,11 @@ Summary:
 
 Notes:
 - 過去Issueの移行が未完了だったため再作業として実施
+
+## 2026-01-19T19:49:16+0900
+Summary:
+- Cut座標派生API（getCutFacePolygon/getCutLines）を削除
+- Cutter仕様から座標起点APIの記述を除去
+
+Notes:
+- CutはSnapPointIDのみを真実とする方針に統一

--- a/docs/specs/cutter/cutter_spec.md
+++ b/docs/specs/cutter/cutter_spec.md
@@ -67,7 +67,6 @@ Cutter モジュールは、3D立方体の切断処理を担当するコアコ�
     flipCut(): void
     reset(): void
     getIntersections(): IntersectionPoint[]
-    getCutLines(): Line3[]
     ```
 
 ---

--- a/js/Cutter.ts
+++ b/js/Cutter.ts
@@ -730,22 +730,6 @@ export class Cutter {
       return this.outlineRefs;
   }
 
-  /** @returns {CutFacePolygon | null} */
-  getCutFacePolygon() {
-      if (!this.outlineRefs || this.outlineRefs.length < 3) return null;
-      const vertices = this.outlineRefs
-          .map(ref => (ref ? this.resolveIntersectionPosition(ref) : null))
-          .filter((pos): pos is THREE.Vector3 => pos instanceof THREE.Vector3)
-          .map(pos => pos.clone());
-      if (vertices.length < 3) return null;
-      return {
-          faceId: 'F:cut',
-          type: 'cut',
-          vertices,
-          normal: this.cutPlane ? this.cutPlane.normal.clone() : undefined
-      };
-  }
-
   /** @returns {Array<{ startId: SnapPointID, endId: SnapPointID, faceIds?: string[] }>} */
   getCutSegments() {
       return this.cutSegments.slice();
@@ -986,29 +970,6 @@ export class Cutter {
           intersections: this.intersectionRefs.slice(),
           cutSegments: this.getCutSegments(),
       };
-  }
-
-  // 展開図描画用に切断線のリスト（Line3配列）を返す
-  getCutLines() {
-      if (!this.outline || !this.outline.geometry) return [];
-      
-      const points = [];
-      const position = this.outline.geometry.attributes.position;
-      for (let i = 0; i < position.count; i++) {
-          points.push(new THREE.Vector3().fromBufferAttribute(position, i));
-      }
-      
-      // outlineは LINE_STRIP 形式（Lineコンストラクタで作った場合）
-      // ただし points は [p0, p1, ..., pn, p0] のようにループしているはず（コード上の生成ロジック確認）
-      // this.outline = new THREE.Line(..., setFromPoints(linePoints))
-      // linePoints = [...intersections, intersections[0]]
-      // なので、i と i+1 を結べばよい。
-      
-      const lines = [];
-      for (let i = 0; i < points.length - 1; i++) {
-          lines.push(new THREE.Line3(points[i], points[i+1]));
-      }
-      return lines;
   }
 
   togglePyramid(visible) {


### PR DESCRIPTION
## 変更点
- Cutの座標派生API（getCutFacePolygon/getCutLines）を削除
- Cutter仕様から該当API記述を削除
- 作業ログに方針統一を記録

## 理由
- Cutの真実の状態をSnapPointIDのみに統一するため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- Cut座標派生APIを利用している外部呼び出しがある場合に影響

## ロールバック
- このPRのコミットをrevert

## 関連Issue
- Fixes #84

## 依存関係
- Depends on #なし
- [ ] なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
