### PR TITLE
#85 [REF] remove cut derived coordinates

### DIFF
--- a/docs/migration/coordinate_dependency_inventory.md
+++ b/docs/migration/coordinate_dependency_inventory.md
@@ -37,11 +37,11 @@ Summary: 座標依存箇所を棚卸しし、SnapPointID/Resolver 起点への�
 
 ## 移行優先度（提案）
 1) Cut/交点/切断線の保持を SnapPointID 起点に整理
-   - `IntersectionPoint.position` や `cutSegments.start/end` を派生情報へ寄せる
+   - `IntersectionPoint.position` や `cutSegments.start/end` は廃止し、resolver で都度解決
 2) Net 展開の投影/面同定を Resolver 起点に統一
    - 面/辺の同定に座標フォールバックを持たない構成へ
 3) CutFacePolygon の頂点保持を SnapPointID 起点へ移行
-   - `CutFacePolygon.vertices` を削除できる状態へ寄せる
+   - `CutFacePolygon.vertices` は削除済み（IDのみを保持）
 
 ## 次のアクション
 - Issue #10/#11/#12/#13 の順に詳細移行計画へ落とし込む

--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -402,7 +402,7 @@ Summary:
 - cutSegments と faceAdjacency を ID ベースで正規化
 
 Notes:
-- IntersectionPoint の position や sharedEdge を保存せず、必要時に resolver で再計算
+- IntersectionPoint の position や sharedEdgeIds を保存せず、必要時に resolver で再計算
 
 ## 2026-01-19T15:19:45+0900
 Summary:
@@ -481,3 +481,19 @@ Summary:
 
 Notes:
 - CutはSnapPointIDのみを真実とする方針に統一
+
+## 2026-01-19T20:00:54+0900
+Summary:
+- Cut関連の派生座標フィールドを削除（IntersectionPoint.position / CutSegment start/end / sharedEdge）
+- resolver からの都度解決に統一
+
+Notes:
+- Cutの真実はSnapPointIDのみ
+
+## 2026-01-19T20:02:36+0900
+Summary:
+- CutFacePolygon から座標派生フィールドを削除（vertices/normal）
+- Cut/Intersection の派生座標依存を整理
+
+Notes:
+- Cutの真実はSnapPointIDのみ

--- a/js/Cutter.ts
+++ b/js/Cutter.ts
@@ -76,7 +76,6 @@ export class Cutter {
 
   resolveIntersectionPosition(ref: IntersectionPoint, resolverOverride: any = null) {
     if (!ref) return null;
-    if (ref.position instanceof THREE.Vector3) return ref.position;
     const resolver = resolverOverride || this.lastResolver;
     if (!resolver || !ref.id) return null;
     return resolver.resolveSnapPoint(ref.id) || null;
@@ -890,7 +889,7 @@ export class Cutter {
       return polygons;
   }
 
-  /** @returns {Array<{ a: string; b: string; sharedEdge: [THREE.Vector3, THREE.Vector3] }>} */
+  /** @returns {Array<{ a: string; b: string; sharedEdgeIds?: [SnapPointID, SnapPointID] }>} */
   getResultFaceAdjacency() {
       const polygons = this.getResultFacePolygons();
       return buildFaceAdjacency(polygons);
@@ -998,7 +997,7 @@ export class Cutter {
     this.vertexMarkers = [];
   }
 
-  updateCutPointMarkers(intersections: Array<IntersectionPoint & { position: THREE.Vector3 }>) {
+  updateCutPointMarkers(intersections: IntersectionPoint[]) {
     this.clearCutPointMarkers();
     if (!intersections || !intersections.length) return;
     const selectionIds = new Set(

--- a/js/SelectionManager.ts
+++ b/js/SelectionManager.ts
@@ -50,9 +50,7 @@ export class SelectionManager {
           .forEach(ref => {
               const edgeId = ref.edgeId || null;
               if (!edgeId) return;
-              const point = ref.position
-                  ? ref.position
-                  : (this.resolver ? this.resolver.resolveSnapPoint(ref.id) : null);
+              const point = this.resolver ? this.resolver.resolveSnapPoint(ref.id) : null;
               if (!point) return;
               const edgeIdx = this.cube.getEdgeMeshIndexById(edgeId);
               if (edgeIdx !== -1 && edgeIdx !== null) {

--- a/js/model/objectModel.ts
+++ b/js/model/objectModel.ts
@@ -56,18 +56,12 @@ export type ObjectSolid = {
 export type ObjectCutSegment = {
   startId: SnapPointID;
   endId: SnapPointID;
-  // Derived from GeometryResolver; not source of truth.
-  start?: THREE.Vector3;
-  // Derived from GeometryResolver; not source of truth.
-  end?: THREE.Vector3;
   faceIds?: string[];
 };
 
 export type ObjectCutAdjacency = {
   a: string;
   b: string;
-  // Derived from GeometryResolver; not source of truth.
-  sharedEdge?: [THREE.Vector3, THREE.Vector3];
 };
 
 export type ObjectCut = {

--- a/js/model/objectModelManager.ts
+++ b/js/model/objectModelManager.ts
@@ -264,9 +264,7 @@ export class ObjectModelManager {
     return this.cutIntersections
       .map(ref => {
         if (!ref || !ref.id) return null;
-        const position = ref.position instanceof THREE.Vector3
-          ? (ref.position as THREE.Vector3).clone()
-          : this.resolver.resolveSnapPoint(ref.id);
+        const position = this.resolver.resolveSnapPoint(ref.id);
         if (!position) return null;
         return { ...ref, position };
       })

--- a/js/types.ts
+++ b/js/types.ts
@@ -34,8 +34,6 @@ export type IntersectionPoint = {
   edgeId?: string;
   ratio?: Ratio;
   faceIds?: string[];
-  // Derived via GeometryResolver; not source of truth.
-  position?: unknown;
 };
 
 export type CutSegmentMeta = {
@@ -62,10 +60,6 @@ export type CutResult = {
   cutSegments: Array<{
     startId: SnapPointID;
     endId: SnapPointID;
-    // Derived via GeometryResolver; not source of truth.
-    start?: unknown;
-    // Derived via GeometryResolver; not source of truth.
-    end?: unknown;
     faceIds?: string[];
   }>;
 };
@@ -73,9 +67,7 @@ export type CutResult = {
 export type CutFacePolygon = {
   faceId: string;
   type: 'cut' | 'original';
-  vertices?: unknown[];
   vertexIds?: SnapPointID[];
-  normal?: unknown;
   sourceFaceId?: string;
 };
 

--- a/tests/unit/cutter_cut_point_markers.test.js
+++ b/tests/unit/cutter_cut_point_markers.test.js
@@ -7,10 +7,18 @@ describe('Cutter cut point markers', () => {
     const scene = new THREE.Scene();
     const cutter = new Cutter(scene);
 
+    cutter.lastResolver = {
+      resolveSnapPoint: (id) => {
+        if (id === 'V:0') return new THREE.Vector3(0, 0, 0);
+        if (id === 'E:01@1/2') return new THREE.Vector3(0.5, 0, 0);
+        if (id === 'V:1') return new THREE.Vector3(1, 0, 0);
+        return null;
+      }
+    };
     cutter.updateCutPointMarkers([
-      { id: 'V:0', type: 'snap', position: new THREE.Vector3(0, 0, 0) },
-      { id: 'E:01@1/2', type: 'intersection', position: new THREE.Vector3(0.5, 0, 0) },
-      { id: 'V:1', type: 'intersection', position: new THREE.Vector3(1, 0, 0) }
+      { id: 'V:0', type: 'snap' },
+      { id: 'E:01@1/2', type: 'intersection' },
+      { id: 'V:1', type: 'intersection' }
     ]);
 
     expect(cutter.vertexMarkers.length).toBe(2);

--- a/tests/unit/object_model_manager.test.js
+++ b/tests/unit/object_model_manager.test.js
@@ -81,7 +81,7 @@ describe('object model manager', () => {
     }
   });
 
-  it('resolves cut intersection positions via resolver only when needed', () => {
+  it('resolves cut intersection positions via resolver', () => {
     const scene = new THREE.Scene();
     const cube = new Cube(scene, 10);
     const resolver = new GeometryResolver({ size: cube.getSize(), indexMap: cube.getIndexMap() });
@@ -90,7 +90,7 @@ describe('object model manager', () => {
 
     const resolveSpy = vi.spyOn(resolver, 'resolveSnapPoint');
     manager.applyCutIntersections([
-      { id: 'V:0', type: 'intersection', position: new THREE.Vector3(1, 2, 3) },
+      { id: 'V:0', type: 'intersection' },
       { id: 'E:01@1/2', type: 'intersection' }
     ]);
 
@@ -111,30 +111,25 @@ describe('object model manager', () => {
     const manager = new ObjectModelManager({ cube, resolver, ui: null });
     manager.build();
 
-    const start = new THREE.Vector3(0, 0, 0);
-    const end = new THREE.Vector3(1, 0, 0);
     const polygon = {
       faceId: 'F:test',
       type: 'original',
-      vertices: [new THREE.Vector3(0, 0, 0), new THREE.Vector3(1, 0, 0), new THREE.Vector3(1, 1, 0)],
-      normal: new THREE.Vector3(0, 0, 1)
+      vertexIds: ['V:0', 'V:1', 'V:2']
     };
 
     manager.syncCutState({
       intersections: [{ id: 'V:0', type: 'intersection' }],
-      cutSegments: [{ startId: 'V:0', endId: 'V:1', start, end }],
+      cutSegments: [{ startId: 'V:0', endId: 'V:1' }],
       facePolygons: [polygon],
-      faceAdjacency: [{ a: 'F:test', b: 'F:neighbor', sharedEdge: [start, end] }]
+      faceAdjacency: [{ a: 'F:test', b: 'F:neighbor' }]
     });
 
     const model = manager.getModel();
     expect(model.cut.cutSegments.length).toBe(1);
-    expect(model.cut.cutSegments[0].start).toBeUndefined();
-    expect(model.cut.cutSegments[0].end).toBeUndefined();
     expect(manager.getCutSegments().length).toBe(1);
     expect(model.cut.facePolygons.length).toBe(1);
     expect(manager.getCutFaceAdjacency().length).toBe(1);
-    expect(manager.getCutFaceAdjacency()[0].sharedEdge).toBeUndefined();
+    expect(manager.getCutFaceAdjacency()[0].sharedEdgeIds).toBeUndefined();
   });
 
   it('syncs net state', () => {

--- a/tests/unit/user_preset_state.test.js
+++ b/tests/unit/user_preset_state.test.js
@@ -14,16 +14,16 @@ describe('buildUserPresetState', () => {
       isCutInverted: () => true,
       getCutResult: () => ({
         outline: { points: [
-          { id: 'V:0', type: /** @type {'snap'} */ ('snap'), position: { x: 0 } },
-          { id: 'E:01@1/2', type: /** @type {'intersection'} */ ('intersection'), position: { x: 0 } },
-          { id: 'E:12@1/4', type: /** @type {'intersection'} */ ('intersection'), position: { x: 0 } }
+          { id: 'V:0', type: /** @type {'snap'} */ ('snap') },
+          { id: 'E:01@1/2', type: /** @type {'intersection'} */ ('intersection') },
+          { id: 'E:12@1/4', type: /** @type {'intersection'} */ ('intersection') }
         ] },
         intersections: [
-          { id: 'V:0', type: /** @type {'snap'} */ ('snap'), position: { x: 0 } },
-          { id: 'E:01@1/2', type: /** @type {'intersection'} */ ('intersection'), edgeId: 'E:01', ratio: { numerator: 1, denominator: 2 }, faceIds: ['F:0154'], position: { x: 0 } }
+          { id: 'V:0', type: /** @type {'snap'} */ ('snap') },
+          { id: 'E:01@1/2', type: /** @type {'intersection'} */ ('intersection'), edgeId: 'E:01', ratio: { numerator: 1, denominator: 2 }, faceIds: ['F:0154'] }
         ],
         cutSegments: [
-          { startId: 'V:0', endId: 'E:01@1/2', start: { x: 0 }, end: { x: 1 }, faceIds: ['F:0154'] }
+          { startId: 'V:0', endId: 'E:01@1/2', faceIds: ['F:0154'] }
         ]
       })
     };


### PR DESCRIPTION
## 変更点
- Cut/Intersectionの派生座標フィールドを削除
- CutFacePolygonの座標派生フィールドを削除
- 関連コード・テストをIDベースに統一
- 移行ログと座標依存インベントリを更新

## 理由
- Cutの真実の状態をSnapPointIDのみに統一するため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- IntersectionPoint.position など派生座標を期待する呼び出しがある場合に影響

## ロールバック
- このPRのコミットをrevert

## 関連Issue
- Fixes #85

## 依存関係
- Depends on #なし
- [ ] なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
