### PR TITLE
#87 [DOC] align snap point specs with id-only model

### DIFF
--- a/docs/architecture/snap_point_id_spec.md
+++ b/docs/architecture/snap_point_id_spec.md
@@ -56,12 +56,12 @@ interface SnapPoint {
     denominator: number;
   };
   face?: Face;                // type='face' の場合
-  position: THREE.Vector3;    // 座標
+  position?: THREE.Vector3;   // 派生座標（必要時のみ算出）
 }
 ```
 
 - Cutter や SelectionManager はこの構造を使う
-- SnapPointID から座標を算出可能
+- SnapPointID から座標を算出可能（派生情報）
 - 教育用ハイライト、解説生成で必須情報
 
 ---
@@ -98,8 +98,8 @@ interface SnapPoint {
 - Edge 型: `v1.position.lerp(v2.position, numerator/denominator)` で座標算出
 
 ### 7.2 座標 → SnapPointID（スナップ時）
-- Edge 上の座標を最も近いスナップ比率（有理数）に丸め
-- Vertex に近ければ Vertex 型 SnapPointID
+- 入力座標は UI からのみ受け取り、SnapPointID に正規化する
+- 以降の処理は SnapPointID を真実として扱う
 
 ---
 

--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -497,3 +497,11 @@ Summary:
 
 Notes:
 - Cutの真実はSnapPointIDのみ
+
+## 2026-01-19T20:31:45+0900
+Summary:
+- SnapPoint/PlaneBuilder 仕様で座標は派生情報と明記
+- ID主導の前提をドキュメントに反映
+
+Notes:
+- 実装の方針と文書の整合を再確認

--- a/docs/specs/geometry/plane_builder_spec.md
+++ b/docs/specs/geometry/plane_builder_spec.md
@@ -11,7 +11,7 @@ docs/specs/geometry/plane_builder_spec.md
 ## 目的
 - 3 つ以上の SnapPoint から切断平面を安定的に生成する。
 - 浮動小数点誤差の影響を低減。
-- SnapPointID を活用して、教育用や構造主体アーキテクチャに対応する平面情報を保持。
+- SnapPointID を活用して、構造主体アーキテクチャに対応する平面情報を保持。
 
 ---
 
@@ -39,7 +39,7 @@ docs/specs/geometry/plane_builder_spec.md
 
     interface SnapPoint {
         id: string;        // SnapPointID
-        position: THREE.Vector3;
+        position?: THREE.Vector3; // 派生座標（必要時のみ算出）
         type: 'vertex' | 'edge' | 'face';
         edgeRatio?: { numerator: number; denominator: number };
         faceId?: string;
@@ -50,4 +50,5 @@ docs/specs/geometry/plane_builder_spec.md
 ## 作業上の注意
 - 常に 3 点が同一直線上でないことを保証する。
 - Plane.normal は正規化済みで返す。
-- SnapPointID を保持して教育表示や交点計算に連動可能とする。
+- SnapPointID を保持して交点計算に連動可能とする。
+- 座標は派生情報としてのみ扱う。


### PR DESCRIPTION
## 変更点
- SnapPoint/PlaneBuilder 仕様で座標は派生情報と明記
- ID主導の前提をドキュメントに反映
- 作業ログを更新

## 理由
- 座標を真実の状態にしない方針を明確化するため

## テスト
- [ ] npm run typecheck（docsのみのため未実行）
- [ ] npm test（docsのみのため未実行）

## 影響/リスク
- ドキュメントのみ

## ロールバック
- このPRのコミットをrevert

## 関連Issue
- Fixes #87

## 依存関係
- Depends on #なし
- [ ] なし

## Definition of Done
- [ ] npm run typecheck（docsのみのため未実行）
- [ ] npm test（docsのみのため未実行）
- [ ] 主要ユースケースの手動確認（不要）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
