### PR TITLE
#75 [REF] normalize face graph inputs

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -505,3 +505,11 @@ Summary:
 
 Notes:
 - 実装の方針と文書の整合を再確認
+
+## 2026-01-19T20:47:12+0900
+Summary:
+- CutFacePolygon の vertexIds を正規化し、面法線に合わせて winding を統一
+- 共有辺判定の前処理として ID の正規化を追加
+
+Notes:
+- 面グラフ構築の前処理を強化


### PR DESCRIPTION
## 変更点
- CutFacePolygon の vertexIds を正規化し、面法線に合わせて winding を統一
- 共有辺判定の前処理として ID 正規化を追加
- 作業ログ更新

## 理由
- 面グラフ構築で共有辺の同定と法線向きを安定させるため

## テスト
- [x] npm run typecheck
- [x] npm test

## 影響/リスク
- CutFacePolygon の並び順が正規化される

## ロールバック
- このPRのコミットをrevert

## 関連Issue
- Fixes #75

## 依存関係
- Depends on #なし
- [ ] なし

## Definition of Done
- [x] npm run typecheck
- [x] npm test
- [ ] 主要ユースケースの手動確認（必要な場合）
- [x] ドキュメント更新（必要な場合）
- [ ] 破壊的変更なら migration note / release note を追加
