### PR TITLE
#97 [BUG] 切断後の展開で Front/Back が入れ替わる

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -545,3 +545,11 @@ Summary:
 
 Notes:
 - 切断前の展開処理は維持
+
+## 2026-01-19T21:59:50+0900
+Summary:
+- 切断後の面同定で resolver の face 情報を基準に参照し、Front/Back の入れ替わりを防止
+- 面ごとの基準平面の算出を resolver に統一
+
+Notes:
+- __DEBUG_NET_MATCH の調査結果を反映


### PR DESCRIPTION
変更点:
- 切断後の面候補フレームを resolver.resolveFace() から取得するように変更
- 面の幅/高さを face vertices の投影から算出し、候補面の基準を統一
- 作業ログに調査結果の反映を追記

理由:
- 面同定が固定コーナー配列に依存しており、Front/Back が入れ替わるため

テスト:
- npm run typecheck
- npm test

影響:
- 切断後の展開面同定
- docs/migration/object_model_worklog.md

Refs #97
