### PR TITLE
#101 [SPIKE] 切断後展開のヒンジ/法線整合をログ化

### DIFF
--- a/docs/migration/object_model_worklog.md
+++ b/docs/migration/object_model_worklog.md
@@ -553,3 +553,11 @@ Summary:
 
 Notes:
 - __DEBUG_NET_MATCH の調査結果を反映
+
+## 2026-01-19T22:54:49+0900
+Summary:
+- 切断後展開のヒンジ選定と面法線をログ化し、向きズレの原因を追跡可能にした
+- 展開木の親子関係と sharedEdgeIds をデバッグ出力するよう整理
+
+Notes:
+- __DEBUG_NET_HINGE でログを有効化


### PR DESCRIPTION
変更点:
- 展開木の親子関係と sharedEdgeIds/hingeType をログ出力
- 面ごとの法線と面タイプをログ出力
- __DEBUG_NET_HINGE が true の時のみ有効
- 作業ログを更新

理由:
- 切断後の面向きズレがヒンジ選定/法線整合に起因するかを判定するため

テスト:
- npm run typecheck
- npm test

影響:
- main.ts
- docs/migration/object_model_worklog.md

Refs #101
