### PR TITLE
[#137] SSOTからのトポロジー逆参照(TopologyIndex)のインデックス化と高速化

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,7 @@ body {
     "imports": {
       "three": "./lib/three/build/three.module.js",
       "three/addons/": "./lib/three/examples/jsm/",
+      "three/examples/jsm/": "./lib/three/examples/jsm/",
       "three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.7.3/build/index.module.js",
       "three-bvh-csg": "https://unpkg.com/three-bvh-csg@0.0.16/build/index.module.js",
       "react": "https://esm.sh/react@18",

--- a/js/Cutter.ts
+++ b/js/Cutter.ts
@@ -104,7 +104,7 @@ export class Cutter {
   private refreshNormalHelper(mesh: THREE.Mesh) {
     if (!this.showNormalHelper) return;
     this.clearNormalHelper();
-    const helper = new VertexNormalsHelper(mesh, 0.3, 0x003366);
+    const helper = new VertexNormalsHelper(mesh, 0.6, 0x990000);
     helper.visible = this.visible;
     this.scene.add(helper);
     this.normalHelper = helper;

--- a/js/Cutter.ts
+++ b/js/Cutter.ts
@@ -104,7 +104,7 @@ export class Cutter {
   private refreshNormalHelper(mesh: THREE.Mesh) {
     if (!this.showNormalHelper) return;
     this.clearNormalHelper();
-    const helper = new VertexNormalsHelper(mesh, 0.3, 0x00ff00);
+    const helper = new VertexNormalsHelper(mesh, 0.3, 0x003366);
     helper.visible = this.visible;
     this.scene.add(helper);
     this.normalHelper = helper;

--- a/js/model/objectModel.ts
+++ b/js/model/objectModel.ts
@@ -136,6 +136,13 @@ export type NetDerived = {
   visible: boolean;
 };
 
+export type TopologyIndex = {
+  vertexToEdges: Record<VertexID, EdgeID[]>;
+  vertexToFaces: Record<VertexID, FaceID[]>;
+  edgeToFaces: Record<EdgeID, FaceID[]>;
+  faceAdjacency: Record<FaceID, FaceID[]>;
+};
+
 // --- Root Model ---
 
 export type ObjectModel = {
@@ -144,6 +151,7 @@ export type ObjectModel = {
   derived: {
     cut?: CutDerived;
     net?: NetDerived;
+    topologyIndex?: TopologyIndex;
   };
 };
 

--- a/js/model/objectModelManager.ts
+++ b/js/model/objectModelManager.ts
@@ -29,6 +29,7 @@ import {
   createDefaultNetDerived
 } from './objectModel.js';
 import { buildObjectModelData } from './objectModelBuilder.js';
+import { buildTopologyIndex } from './topologyIndex.js';
 import { normalizeSnapPointId, parseSnapPointId } from '../geometry/snapPointId.js';
 import { buildCubeStructure } from '../structure/structureModel.js';
 
@@ -102,6 +103,11 @@ export class ObjectModelManager {
     this.listeners.forEach(l => l(event));
   }
 
+  private rebuildTopologyIndex() {
+    if (!this.model) return;
+    this.model.derived.topologyIndex = buildTopologyIndex(this.model.ssot);
+  }
+
   build(displayOverride?: DisplayState) {
     const structure = this.cube.getStructure() || buildCubeStructure({ indexMap: this.cube.getIndexMap() });
     const display = displayOverride || (this.ui ? this.ui.getDisplayState() : DEFAULT_DISPLAY);
@@ -123,7 +129,8 @@ export class ObjectModelManager {
       presentation: built.presentation,
       derived: {
         cut: createDefaultCutDerived(),
-        net: createDefaultNetDerived()
+        net: createDefaultNetDerived(),
+        topologyIndex: buildTopologyIndex(built.ssot)
       }
     };
     
@@ -411,6 +418,8 @@ export class ObjectModelManager {
     this.model.presentation.faces = newPresFaces;
     this.model.presentation.edges = newPresEdges;
     this.model.presentation.vertices = newPresVertices;
+
+    this.rebuildTopologyIndex();
   }
 
   syncCutState({

--- a/js/model/topologyIndex.ts
+++ b/js/model/topologyIndex.ts
@@ -1,0 +1,81 @@
+import type { EdgeID, FaceID, SolidSSOT, TopologyIndex, VertexID } from './objectModel.js';
+
+const ensureArray = <T>(record: Record<string, T[]>, key: string) => {
+  if (!record[key]) record[key] = [] as T[];
+  return record[key];
+};
+
+export const buildTopologyIndex = (ssot: SolidSSOT): TopologyIndex => {
+  const vertexToEdges: Record<VertexID, EdgeID[]> = {};
+  const vertexToFaces: Record<VertexID, FaceID[]> = {};
+  const edgeToFaces: Record<EdgeID, FaceID[]> = {};
+  const faceAdjacencySets: Record<FaceID, Set<FaceID>> = {};
+
+  Object.values(ssot.vertices).forEach(vertex => {
+    vertexToEdges[vertex.id] = [];
+    vertexToFaces[vertex.id] = [];
+  });
+
+  Object.values(ssot.edges).forEach(edge => {
+    edgeToFaces[edge.id] = [];
+    ensureArray(vertexToEdges, edge.v0).push(edge.id);
+    ensureArray(vertexToEdges, edge.v1).push(edge.id);
+  });
+
+  const edgeKeyToId = new Map<string, EdgeID>();
+  Object.values(ssot.edges).forEach(edge => {
+    edgeKeyToId.set(`${edge.v0}|${edge.v1}`, edge.id);
+    edgeKeyToId.set(`${edge.v1}|${edge.v0}`, edge.id);
+  });
+
+  Object.values(ssot.faces).forEach(face => {
+    faceAdjacencySets[face.id] = new Set();
+    face.vertices.forEach(vertexId => {
+      ensureArray(vertexToFaces, vertexId).push(face.id);
+    });
+
+    for (let i = 0; i < face.vertices.length; i++) {
+      const v0 = face.vertices[i];
+      const v1 = face.vertices[(i + 1) % face.vertices.length];
+      const edgeId = edgeKeyToId.get(`${v0}|${v1}`);
+      if (!edgeId) continue;
+      ensureArray(edgeToFaces, edgeId).push(face.id);
+    }
+  });
+
+  Object.values(edgeToFaces).forEach(faceIds => {
+    const uniqueFaces = Array.from(new Set(faceIds));
+    for (let i = 0; i < uniqueFaces.length; i++) {
+      for (let j = i + 1; j < uniqueFaces.length; j++) {
+        const a = uniqueFaces[i];
+        const b = uniqueFaces[j];
+        if (!faceAdjacencySets[a]) faceAdjacencySets[a] = new Set();
+        if (!faceAdjacencySets[b]) faceAdjacencySets[b] = new Set();
+        faceAdjacencySets[a].add(b);
+        faceAdjacencySets[b].add(a);
+      }
+    }
+  });
+
+  const faceAdjacency: Record<FaceID, FaceID[]> = {};
+  Object.keys(faceAdjacencySets).forEach(faceId => {
+    faceAdjacency[faceId] = Array.from(faceAdjacencySets[faceId]);
+  });
+
+  Object.keys(vertexToEdges).forEach(vertexId => {
+    vertexToEdges[vertexId] = Array.from(new Set(vertexToEdges[vertexId]));
+  });
+  Object.keys(vertexToFaces).forEach(vertexId => {
+    vertexToFaces[vertexId] = Array.from(new Set(vertexToFaces[vertexId]));
+  });
+  Object.keys(edgeToFaces).forEach(edgeId => {
+    edgeToFaces[edgeId] = Array.from(new Set(edgeToFaces[edgeId]));
+  });
+
+  return {
+    vertexToEdges,
+    vertexToFaces,
+    edgeToFaces,
+    faceAdjacency
+  };
+};

--- a/lib/three/examples/jsm/helpers/VertexNormalsHelper.js
+++ b/lib/three/examples/jsm/helpers/VertexNormalsHelper.js
@@ -1,0 +1,155 @@
+import {
+	BufferGeometry,
+	Float32BufferAttribute,
+	LineSegments,
+	LineBasicMaterial,
+	Matrix3,
+	Vector3
+} from 'three';
+
+const _v1 = new Vector3();
+const _v2 = new Vector3();
+const _normalMatrix = new Matrix3();
+
+/**
+ * Visualizes an object's vertex normals.
+ *
+ * Requires that normals have been specified in the geometry as a buffer attribute or
+ * have been calculated using {@link BufferGeometry#computeVertexNormals}.
+ * ```js
+ * const geometry = new THREE.BoxGeometry( 10, 10, 10, 2, 2, 2 );
+ * const material = new THREE.MeshStandardMaterial();
+ * const mesh = new THREE.Mesh( geometry, material );
+ * scene.add( mesh );
+ *
+ * const helper = new VertexNormalsHelper( mesh, 1, 0xff0000 );
+ * scene.add( helper );
+ * ```
+ *
+ * @augments LineSegments
+ * @three_import import { VertexNormalsHelper } from 'three/addons/helpers/VertexNormalsHelper.js';
+ */
+class VertexNormalsHelper extends LineSegments {
+
+	/**
+	 * Constructs a new vertex normals helper.
+	 *
+	 * @param {Object3D} object - The object for which to visualize vertex normals.
+	 * @param {number} [size=1] - The helper's size.
+	 * @param {number|Color|string} [color=0xff0000] - The helper's color.
+	 */
+	constructor( object, size = 1, color = 0xff0000 ) {
+
+		const geometry = new BufferGeometry();
+
+		const nNormals = object.geometry.attributes.normal.count;
+		const positions = new Float32BufferAttribute( nNormals * 2 * 3, 3 );
+
+		geometry.setAttribute( 'position', positions );
+
+		super( geometry, new LineBasicMaterial( { color, toneMapped: false } ) );
+
+		/**
+		 * The object for which to visualize vertex normals.
+		 *
+		 * @type {Object3D}
+		 */
+		this.object = object;
+
+		/**
+		 * The helper's size.
+		 *
+		 * @type {number}
+		 * @default 1
+		 */
+		this.size = size;
+
+		this.type = 'VertexNormalsHelper';
+
+		/**
+		 * Overwritten and set to `false` since the object's world transformation
+		 * is encoded in the helper's geometry data.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.matrixAutoUpdate = false;
+
+		/**
+		 * This flag can be used for type testing.
+		 *
+		 * @type {boolean}
+		 * @readonly
+		 * @default true
+		 */
+		this.isVertexNormalsHelper = true;
+
+		this.update();
+
+	}
+
+	/**
+	 * Updates the vertex normals preview based on the object's world transform.
+	 */
+	update() {
+
+		this.object.updateMatrixWorld( true );
+
+		_normalMatrix.getNormalMatrix( this.object.matrixWorld );
+
+		const matrixWorld = this.object.matrixWorld;
+
+		const position = this.geometry.attributes.position;
+
+		//
+
+		const objGeometry = this.object.geometry;
+
+		if ( objGeometry ) {
+
+			const objPos = objGeometry.attributes.position;
+
+			const objNorm = objGeometry.attributes.normal;
+
+			let idx = 0;
+
+			// for simplicity, ignore index and drawcalls, and render every normal
+
+			for ( let j = 0, jl = objPos.count; j < jl; j ++ ) {
+
+				_v1.fromBufferAttribute( objPos, j ).applyMatrix4( matrixWorld );
+
+				_v2.fromBufferAttribute( objNorm, j );
+
+				_v2.applyMatrix3( _normalMatrix ).normalize().multiplyScalar( this.size ).add( _v1 );
+
+				position.setXYZ( idx, _v1.x, _v1.y, _v1.z );
+
+				idx = idx + 1;
+
+				position.setXYZ( idx, _v2.x, _v2.y, _v2.z );
+
+				idx = idx + 1;
+
+			}
+
+		}
+
+		position.needsUpdate = true;
+
+	}
+
+	/**
+	 * Frees the GPU-related resources allocated by this instance. Call this
+	 * method whenever this instance is no longer used in your app.
+	 */
+	dispose() {
+
+		this.geometry.dispose();
+		this.material.dispose();
+
+	}
+
+}
+
+export { VertexNormalsHelper };

--- a/main.ts
+++ b/main.ts
@@ -356,8 +356,9 @@ class App {
 
         const solid = this.objectModelManager.getModel()?.ssot;
         if (!solid) return;
+        const topologyIndex = this.objectModelManager.getModel()?.derived.topologyIndex || null;
 
-        const success = this.cutter.cut(solid, snapIds, this.resolver);
+        const success = this.cutter.cut(solid, snapIds, this.resolver, { topologyIndex });
         if (!success) {
             console.warn("切断処理に失敗しました。点を選択し直してください。");
             this.isCutExecuted = false;
@@ -368,7 +369,7 @@ class App {
         const modelDisplay = this.objectModelManager.getDisplayState();
         this.cutter.setTransparency(modelDisplay.cubeTransparent);
 
-        const cutState = this.cutter.computeCutState(solid, snapIds, this.resolver);
+        const cutState = this.cutter.computeCutState(solid, snapIds, this.resolver, topologyIndex);
 
         if (cutState) {
             this.objectModelManager.syncCutState({

--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@ import { normalizeSnapPointId, parseSnapPointId, type SnapPointID } from './js/g
 import { createLabel, createMarker } from './js/utils.js';
 
 const DEBUG = false;
+const SHOW_NORMAL_HELPER = true;
 
 class App {
     isCutExecuted: boolean;
@@ -186,6 +187,7 @@ class App {
         this.resolver = new GeometryResolver({ size: this.cube.getSize(), indexMap: this.cube.getIndexMap() });
         this.cutter = new Cutter(this.scene);
         this.cutter.setDebug(DEBUG);
+        this.cutter.setShowNormalHelper(SHOW_NORMAL_HELPER);
         this.netManager = new NetManager();
         this.netManager.setResolver(this.resolver);
         this.selection = new SelectionManager(this.scene, this.cube, this.ui, this.resolver);


### PR DESCRIPTION
Closes #137

## 概要
- Derived に TopologyIndex を追加し、SSOT から逆参照を構築
- Cutter の SSOT 線形探索を TopologyIndex 参照に置換
- VertexNormalsHelper をスモークテスト用途で残置（importmap と helper 配置を追加）

## 経緯
- SSOT 参照の O(N) 探索がボトルネックになり得るため、Derived でインデックス化

## 実装上の留意点
- TopologyIndex は SSOT 更新時に再構築（build / 切断後の SSOT 更新）
- Legacy 構造の経路は維持し、SSOT のみ index 参照
- `python -m http.server` でも helper が解決できるよう importmap と lib 配置を追加

## レビューしてほしい点
- TopologyIndex の構築ロジック（vertex/edge/face 逆参照の正当性）
- Cutter 側の index 参照切替の影響
- VertexNormalsHelper を今後も常設するか

## テスト
- `npx vitest run`
- `npm run typecheck`
- `npm run build`

## L2 ドキュメント
- なし

## リファクタリング前の状態
- SSOT からの接続関係解決が線形探索に依存

## リファクタリング後の状態
- Derived の TopologyIndex により O(1) 参照に変更
