### PR TITLE
[#146] 暗黙の any 型を禁止する

### DIFF
--- a/js/Cube.ts
+++ b/js/Cube.ts
@@ -4,6 +4,9 @@ import { getDefaultIndexMap } from './geometry/indexMap.js';
 import type { CubeSize } from './types.js';
 import type { GeometryResolver } from './geometry/GeometryResolver.js';
 import type { ObjectModel, VertexID, EdgeID, FaceID } from './model/objectModel.js';
+import type { buildCubeStructure } from './structure/structureModel.js';
+
+type StructureSnapshot = ReturnType<typeof buildCubeStructure>;
 
 export class Cube {
   scene: THREE.Scene;
@@ -31,11 +34,11 @@ export class Cube {
   vertexMeshes: THREE.Mesh[]; 
   edgeMeshes: THREE.Mesh[];
 
-  getVertexObjectById(vertexId: VertexID) {
+  getVertexObjectById(vertexId: VertexID): THREE.Mesh | undefined {
       return this.vertexHitboxes.get(vertexId);
   }
 
-  getEdgeObjectById(edgeId: EdgeID) {
+  getEdgeObjectById(edgeId: EdgeID): THREE.Mesh | undefined {
       if (!edgeId) return undefined;
       const normalized = edgeId.startsWith('E:') ? edgeId : `E:${edgeId}`;
       return this.edgeHitboxes.get(normalized);
@@ -49,12 +52,12 @@ export class Cube {
       return `E:${index}`; // Temporary mapping
   }
 
-  getVertexObjectByName(name: string) {
+  getVertexObjectByName(name: string): THREE.Mesh | undefined {
       // Mapping name back to ID would require presentation model
       return undefined; 
   }
 
-  getEdgeObjectByName(name: string) {
+  getEdgeObjectByName(name: string): THREE.Mesh | undefined {
       return undefined;
   }
 
@@ -548,6 +551,6 @@ export class Cube {
       return this.displayLabelMap ? this.displayLabelMap[`V:${index}`] : `V:${index}`; 
   }
   getIndexMap() { return this.indexMap; }
-  getStructure() { return null; }
+  getStructure(): StructureSnapshot | null { return null; }
   getSize() { return this.edgeLengths; }
 }

--- a/js/Cutter.ts
+++ b/js/Cutter.ts
@@ -1581,7 +1581,7 @@ export class Cutter {
     const cutSegments: CutSegmentMeta[] = cutPoints.map((p, i) => ({
         startId: p.ref.id,
         endId: cutPoints[(i+1)%cutPoints.length].ref.id,
-        faceIds: [] 
+        faceIds: [] as string[]
     }));
     
     const faceAdjacency = buildFaceAdjacency(polygons); 

--- a/js/education/explanationGenerator.ts
+++ b/js/education/explanationGenerator.ts
@@ -52,14 +52,14 @@ function getFaceLabels(structure: StructureSummary | null, faceId: string) {
   if (structure.faceMap) {
     const face = structure.faceMap.get(faceId);
     if (face && face.vertices) {
-      return face.vertices.map(vId => getVertexLabel(structure, vId));
+      return face.vertices.map((vId: string) => getVertexLabel(structure, vId));
     }
   }
   
   if (structure.faces) {
     const face = structure.faces[faceId];
     if (face && face.vertices) {
-      return face.vertices.map(vId => getVertexLabel(structure, vId));
+      return face.vertices.map((vId: string) => getVertexLabel(structure, vId));
     }
   }
 

--- a/js/model/objectModelManager.ts
+++ b/js/model/objectModelManager.ts
@@ -11,6 +11,7 @@ type SelectionLike = {
 import {
   type ObjectCutAdjacency,
   type ObjectCutSegment,
+  type CutDerived,
   type ObjectModel,
   type ObjectNetFace,
   type ObjectNetState,
@@ -45,7 +46,7 @@ const DEFAULT_DISPLAY: DisplayState = {
 };
 
 // Helper to create default empty cut derived
-const createDefaultCutDerived = () => ({
+const createDefaultCutDerived = (): CutDerived => ({
   showCutSurface: true,
   intersections: [],
   cutSegments: [],

--- a/js/net/NetManager.ts
+++ b/js/net/NetManager.ts
@@ -256,7 +256,7 @@ export class NetManager {
             // We need to find one that exists in our 2D layout.
             let targetFaceId: string | null = null;
             if (segment.faceIds && segment.faceIds.length > 0) {
-                targetFaceId = segment.faceIds.find(id => faceIndex.has(id)) || null;
+                targetFaceId = segment.faceIds.find((id: string) => faceIndex.has(id)) || null;
             }
             
             // If explicit faceId not found, try to resolve from vertices (fallback)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
+    "noImplicitAny": true,
     "strict": false,
     "baseUrl": "."
   },


### PR DESCRIPTION
Closes #146

## 概要
- tsconfig に `noImplicitAny` を追加
- 暗黙 any を型注釈で解消

## 経緯
- 型安全性向上のため暗黙 any を禁止

## 実装上の留意点
- `Cube`/`Cutter`/`ObjectModelManager`/`NetManager`/`explanationGenerator` で暗黙 any を明示化

## レビューしてほしい点
- noImplicitAny 追加の影響範囲
- 型注釈の妥当性

## テスト
- `npm run typecheck`
- `npx vitest run`
- `npm run build`

## L2 ドキュメント
- なし

## リファクタリング前の状態
- 暗黙 any が発生しうる状態

## リファクタリング後の状態
- noImplicitAny を有効化し暗黙 any を禁止
