### PR TITLE
[#140] Cutterの責務分離（計算/可視化/CSG）

### DIFF
--- a/js/Cutter.ts
+++ b/js/Cutter.ts
@@ -1,11 +1,11 @@
 import * as THREE from 'three';
-import { SUBTRACTION, INTERSECTION, Brush, Evaluator } from 'three-bvh-csg';
-import { VertexNormalsHelper } from 'three/examples/jsm/helpers/VertexNormalsHelper.js';
-import { createMarker } from './utils.js';
 import { buildFaceAdjacency } from './cutter/cutFaceGraph.js';
 import { canonicalizeSnapPointId, normalizeSnapPointId, parseSnapPointId, stringifySnapPointId } from './geometry/snapPointId.js';
 import type { CutFacePolygon, CutResult, CutResultMeta, CutSegmentMeta, IntersectionPoint, Ratio, SnapPointID } from './types.js';
 import type { ObjectCutAdjacency, SolidSSOT, TopologyIndex } from './model/objectModel.js';
+import { CutCSG } from './cutter/CutCSG.js';
+import { CutVisualization } from './cutter/CutVisualization.js';
+import { computeCutState } from './cutter/CutComputation.js';
 
 export class Cutter {
   scene: THREE.Scene;
@@ -13,9 +13,9 @@ export class Cutter {
   removedMesh: THREE.Mesh | null;
   cornerMarker: THREE.Mesh | null;
   originalCube: any;
-  evaluator: Evaluator;
+  csg: CutCSG;
+  visualization: CutVisualization;
   isTransparent: boolean;
-  vertexMarkers: THREE.Object3D[];
   cutInverted: boolean;
   lastSnapIds: SnapPointID[] | null;
   lastResolver: any;
@@ -24,19 +24,8 @@ export class Cutter {
   intersectionRefs: IntersectionPoint[];
   outlineRefs: IntersectionPoint[];
   cutSegments: CutSegmentMeta[];
-  edgeHighlights: THREE.Object3D[];
   cutPlane: THREE.Plane | null;
   keepPositiveSide: boolean | null;
-  outline: THREE.Line | null;
-  cutOverlayGroup: THREE.Group | null;
-  cutLineMaterial: THREE.LineBasicMaterial | null;
-  normalHelper: VertexNormalsHelper | null;
-  showNormalHelper: boolean;
-  showCutPoints: boolean;
-  colorizeCutLines: boolean;
-  cutLineDefaultColor: number;
-  cutLineHighlightColor: number;
-  edgeHighlightColorResolver: ((edgeId: string) => number) | null;
   debug: boolean;
   visible: boolean;
 
@@ -46,12 +35,9 @@ export class Cutter {
     this.removedMesh = null;
     this.cornerMarker = null;
     this.originalCube = null;
-    
-    this.evaluator = new Evaluator();
-    this.evaluator.attributes = ['position', 'normal'];
-    this.evaluator.useGroups = true;
+    this.csg = new CutCSG();
+    this.visualization = new CutVisualization(scene);
     this.isTransparent = true;
-    this.vertexMarkers = [];
     this.cutInverted = false;
     this.lastSnapIds = null;
     this.lastResolver = null;
@@ -60,19 +46,8 @@ export class Cutter {
     this.intersectionRefs = [];
     this.outlineRefs = [];
     this.cutSegments = [];
-    this.edgeHighlights = [];
     this.cutPlane = null;
     this.keepPositiveSide = null;
-    this.outline = null;
-    this.cutOverlayGroup = null;
-    this.cutLineMaterial = null;
-    this.normalHelper = null;
-    this.showNormalHelper = false;
-    this.showCutPoints = true;
-    this.colorizeCutLines = false;
-    this.cutLineDefaultColor = 0x444444;
-    this.cutLineHighlightColor = 0xff0000;
-    this.edgeHighlightColorResolver = null;
     this.debug = false;
     this.visible = true;
   }
@@ -82,33 +57,7 @@ export class Cutter {
   }
 
   setShowNormalHelper(visible: boolean) {
-    this.showNormalHelper = !!visible;
-    if (!this.showNormalHelper) {
-      this.clearNormalHelper();
-      return;
-    }
-    if (this.resultMesh) {
-      this.refreshNormalHelper(this.resultMesh);
-    }
-  }
-
-  private clearNormalHelper() {
-    if (!this.normalHelper) return;
-    this.scene.remove(this.normalHelper);
-    const helper = this.normalHelper as any;
-    if (helper.geometry) helper.geometry.dispose();
-    if (helper.material) helper.material.dispose();
-    this.normalHelper = null;
-  }
-
-  private refreshNormalHelper(mesh: THREE.Mesh) {
-    if (!this.showNormalHelper) return;
-    this.clearNormalHelper();
-    const helper = new VertexNormalsHelper(mesh, 0.6, 0x990000);
-    helper.visible = this.visible;
-    this.scene.add(helper);
-    this.normalHelper = helper;
-    helper.update();
+    this.visualization.setShowNormalHelper(visible, this.resultMesh);
   }
 
   private isSolidSSOT(solid: any): solid is SolidSSOT {
@@ -147,9 +96,7 @@ export class Cutter {
   }
 
   ensureCutOverlayGroup() {
-    if (this.cutOverlayGroup) return;
-    this.cutOverlayGroup = new THREE.Group();
-    this.scene.add(this.cutOverlayGroup);
+    this.visualization.ensureCutOverlayGroup();
   }
 
   getCutPlaneNormal() {
@@ -328,79 +275,23 @@ export class Cutter {
 
         if (!suppressMarkers && this.debug) {
             targetVertices.forEach(v => {
-                this.ensureCutOverlayGroup();
-                const m = createMarker(v, this.scene, 0xff0000, false, this.cutOverlayGroup || undefined);
-                this.vertexMarkers.push(m);
+                this.visualization.addMarker(v, 0xff0000, false);
             });
         }
 
-        const size = solidSize * 5;
-        const geom = new THREE.BoxGeometry(size, size, size);
-
-        const cutBrush = new (Brush as any)(geom) as any;
-
-        const centerOffset = normal.clone().multiplyScalar(size / 2);
-        const brushPos = p0.clone().add(centerOffset);
-        cutBrush.position.copy(brushPos);
-
-        const defaultUp = new THREE.Vector3(0, 1, 0);
-        const quaternion = new THREE.Quaternion().setFromUnitVectors(defaultUp, normal);
-        cutBrush.setRotationFromQuaternion(quaternion);
-
-        cutBrush.updateMatrixWorld();
-
-        let cubeBrush: any;
-        let cubeMat: THREE.Material;
-
-        if (isSSOT) {
-             const { lx, ly, lz } = (cube as SolidSSOT).meta.size;
-             const geometry = new THREE.BoxGeometry(lx, ly, lz);
-             cubeBrush = new (Brush as any)(geometry) as any;
-             cubeBrush.updateMatrixWorld();
-
-             cubeMat = new THREE.MeshBasicMaterial({ color: 0xffffff });
-             cubeMat.side = THREE.DoubleSide;
-             cubeMat.transparent = this.isTransparent;
-             cubeMat.opacity = this.isTransparent ? 0.4 : 1.0;
-             cubeMat.depthWrite = !this.isTransparent;
-        } else {
-             cubeBrush = new (Brush as any)(cube.cubeMesh.geometry.clone()) as any;
-             cubeBrush.position.copy(cube.cubeMesh.position);
-             cubeBrush.rotation.copy(cube.cubeMesh.rotation);
-             cubeBrush.scale.copy(cube.cubeMesh.scale);
-             cubeBrush.updateMatrixWorld();
-
-             cubeMat = cube.cubeMesh.material.clone();
-             cubeMat.side = THREE.DoubleSide;
-             cubeMat.transparent = this.isTransparent;
-             cubeMat.opacity = this.isTransparent ? 0.4 : 1.0;
-             cubeMat.depthWrite = !this.isTransparent;
-        }
-
-        const cutMat = new THREE.MeshBasicMaterial({
-            color: 0xffcccc,
-            side: THREE.DoubleSide,
-            depthTest: true,
-            polygonOffset: true,
-            polygonOffsetFactor: 1,
-            polygonOffsetUnits: 1,
-            transparent: true,
-            opacity: 0.5,
-            depthWrite: false,
-            name: 'cutFace'
+        const csgResult = this.csg.applyCut({
+            cube,
+            plane,
+            planePoint: p0,
+            cutNegative,
+            isTransparent: this.isTransparent,
+            scene: this.scene
         });
-
-        cubeBrush.material = cubeMat;
-        cutBrush.material = cutMat;
-
-        this.resultMesh = (this.evaluator.evaluate(cubeBrush, cutBrush, SUBTRACTION) as THREE.Mesh);
-        this.resultMesh.material = [cubeMat, cutMat];
-        this.scene.add(this.resultMesh);
-        this.refreshNormalHelper(this.resultMesh);
-
-        this.removedMesh = (this.evaluator.evaluate(cubeBrush, cutBrush, INTERSECTION) as THREE.Mesh);
-        this.removedMesh.material = [cubeMat, cutMat];
-        this.scene.add(this.removedMesh);
+        if (csgResult) {
+            this.resultMesh = csgResult.resultMesh;
+            this.removedMesh = csgResult.removedMesh;
+            this.visualization.refreshNormalHelper(this.resultMesh);
+        }
     }
 
     const intersections: THREE.Vector3[] = points.slice();
@@ -550,10 +441,6 @@ export class Cutter {
     });
     this.intersectionRefs = intersectionRefs;
 
-    this.edgeHighlights.forEach(edge => {
-        this.scene.remove(edge);
-    });
-    this.edgeHighlights = [];
     if (resolver && (structure || isSSOT)) {
         const edgeIds = new Map<string, { hasMidpoint: boolean }>();
         intersectionRefs.forEach(ref => {
@@ -608,17 +495,11 @@ export class Cutter {
                 }
             }
         });
-        edgeIds.forEach((meta, edgeId) => {
-            const resolved = resolver.resolveEdge(edgeId);
-            if (!resolved) return;
-            const geometry = new THREE.BufferGeometry().setFromPoints([resolved.start, resolved.end]);
-            const material = new THREE.LineBasicMaterial({ color: this.cutLineDefaultColor });
-            const line = new THREE.Line(geometry, material);
-            line.userData = { type: 'education-edge', edgeId, hasMidpoint: !!(meta && meta.hasMidpoint) };
-            line.visible = this.visible;
-            this.scene.add(line);
-            this.edgeHighlights.push(line);
-        });
+        const edgeMetaList = Array.from(edgeIds.entries()).map(([edgeId, meta]) => ({
+            edgeId,
+            hasMidpoint: !!(meta && meta.hasMidpoint)
+        }));
+        this.visualization.updateEdgeHighlights(edgeMetaList, resolver);
     }
 
     if(intersections.length >= 3){
@@ -767,18 +648,8 @@ export class Cutter {
             });
         }
 
-        const linePoints = [...outlinePoints, outlinePoints[0]];
-        const lineGeo = new THREE.BufferGeometry().setFromPoints(linePoints);
         if (!suppressOutline) {
-            this.ensureCutOverlayGroup();
-            this.cutLineMaterial = new THREE.LineBasicMaterial({
-                color: this.colorizeCutLines ? this.cutLineHighlightColor : this.cutLineDefaultColor,
-                linewidth: 2
-            });
-            this.outline = new THREE.Line(lineGeo, this.cutLineMaterial);
-            if (this.cutOverlayGroup) {
-                this.cutOverlayGroup.add(this.outline);
-            }
+            this.visualization.updateOutline(outlinePoints);
         }
 
         const selectionIds = new Set(
@@ -800,9 +671,7 @@ export class Cutter {
                     const ratio = parsed && parsed.type === 'edge' ? parsed.ratio : null;
                     const isMidpoint = ratio ? ratio.numerator * 2 === ratio.denominator : false;
                     const markerColor = isMidpoint ? 0x00ff00 : 0xffff00;
-                    this.ensureCutOverlayGroup();
-                    const m = createMarker(point, this.scene, markerColor, isMidpoint, this.cutOverlayGroup || undefined);
-                    this.vertexMarkers.push(m);
+                    this.visualization.addMarker(point, markerColor, isMidpoint);
                     created.add(ref.id);
                 });
         }
@@ -1143,14 +1012,13 @@ export class Cutter {
       this.outlineRefs = outlineRefs;
       this.cutSegments = cutSegments;
 
-      if (this.outline && this.outline.geometry && outlineRefs.length >= 3) {
+      if (outlineRefs.length >= 3) {
           const points = outlineRefs
               .map(ref => this.resolveIntersectionPosition(ref, resolver))
               .filter((pos): pos is THREE.Vector3 => pos instanceof THREE.Vector3);
-          const linePoints = [...points, points[0]];
-          const lineGeo = new THREE.BufferGeometry().setFromPoints(linePoints);
-          this.outline.geometry.dispose();
-          this.outline.geometry = lineGeo;
+          if (points.length >= 3) {
+              this.visualization.updateOutline(points);
+          }
       }
       return true;
   }
@@ -1170,24 +1038,11 @@ export class Cutter {
   }
 
   setCutPointsVisible(visible: boolean) {
-    this.showCutPoints = !!visible;
-    const next = this.visible && this.showCutPoints;
-    if (this.cornerMarker) this.cornerMarker.visible = next;
-    this.vertexMarkers.forEach(marker => { marker.visible = next; });
+    this.visualization.setCutPointsVisible(visible);
   }
 
   clearCutPointMarkers() {
-    if (!this.vertexMarkers) return;
-    this.vertexMarkers.forEach(marker => {
-      if (this.cutOverlayGroup) {
-        this.cutOverlayGroup.remove(marker);
-      } else {
-        this.scene.remove(marker);
-      }
-      const m = marker as any;
-      if (m.geometry) m.geometry.dispose();
-    });
-    this.vertexMarkers = [];
+    this.visualization.clearCutPointMarkers();
   }
 
   updateCutPointMarkers(intersections: IntersectionPoint[]) {
@@ -1208,57 +1063,32 @@ export class Cutter {
         const ratio = parsed && parsed.type === 'edge' ? parsed.ratio : null;
         const isMidpoint = ratio ? ratio.numerator * 2 === ratio.denominator : false;
         const markerColor = isMidpoint ? 0x00ff00 : 0xffff00;
-        this.ensureCutOverlayGroup();
-        const marker = createMarker(position.clone(), this.scene, markerColor, isMidpoint, this.cutOverlayGroup || undefined);
-        this.vertexMarkers.push(marker);
+        this.visualization.addMarker(position.clone(), markerColor, isMidpoint);
       });
-    this.setCutPointsVisible(this.showCutPoints);
+    this.visualization.setCutPointsVisible(this.visualization.getCutPointsVisible());
   }
 
   setCutLineColorize(enabled: boolean) {
-    this.colorizeCutLines = !!enabled;
-    this.refreshEdgeHighlightColors();
-    if (this.cutLineMaterial) {
-        this.cutLineMaterial.color.setHex(
-            this.colorizeCutLines ? this.cutLineHighlightColor : this.cutLineDefaultColor
-        );
-        this.cutLineMaterial.needsUpdate = true;
-    }
+    this.visualization.setCutLineColorize(enabled);
   }
 
   setEdgeHighlightColorResolver(resolver: ((edgeId: string) => number) | null) {
-    this.edgeHighlightColorResolver = resolver || null;
-    this.refreshEdgeHighlightColors();
+    this.visualization.setEdgeHighlightColorResolver(resolver);
   }
 
   refreshEdgeHighlightColors() {
-    this.edgeHighlights.forEach(edge => {
-      edge.visible = this.visible;
-      const edgeId = edge.userData ? edge.userData.edgeId : null;
-      const material = (edge as THREE.Line).material;
-      if (!(material instanceof THREE.LineBasicMaterial)) return;
-      let color = this.cutLineDefaultColor;
-      if (this.colorizeCutLines && this.edgeHighlightColorResolver && typeof edgeId === 'string') {
-        color = this.edgeHighlightColorResolver(edgeId);
-      }
-      material.color.setHex(color);
-      material.needsUpdate = true;
-    });
+    this.visualization.refreshEdgeHighlightColors();
   }
 
   updateOverlayVisibility() {
-    const overlayVisible = this.visible;
-    if (this.outline) this.outline.visible = overlayVisible;
-    this.setCutPointsVisible(this.showCutPoints);
+    this.visualization.setVisible(this.visible);
   }
 
   setVisible(visible: boolean) {
     this.visible = !!visible;
     if (this.resultMesh) this.resultMesh.visible = visible;
     if (this.removedMesh) this.removedMesh.visible = visible;
-    this.updateOverlayVisibility();
-    this.edgeHighlights.forEach(edge => { edge.visible = visible; });
-    if (this.normalHelper) this.normalHelper.visible = visible;
+    this.visualization.setVisible(this.visible);
   }
 
   reset() {
@@ -1272,44 +1102,7 @@ export class Cutter {
         this.removedMesh.geometry.dispose();
         this.removedMesh = null;
     }
-    if (this.outline) {
-        if (this.cutOverlayGroup) {
-            this.cutOverlayGroup.remove(this.outline);
-        } else {
-            this.scene.remove(this.outline);
-        }
-        this.outline.geometry.dispose();
-        const mat = this.outline.material;
-        if (Array.isArray(mat)) {
-            mat.forEach(m => m.dispose());
-        } else {
-            mat.dispose();
-        }
-        this.outline = null;
-    }
-    this.cutLineMaterial = null;
-    
-    this.clearCutPointMarkers();
-    if (this.cutOverlayGroup) {
-        this.scene.remove(this.cutOverlayGroup);
-        this.cutOverlayGroup = null;
-    }
-    if (this.edgeHighlights) {
-        this.edgeHighlights.forEach(edge => {
-            this.scene.remove(edge);
-            const e = edge as any;
-            if (e.geometry) e.geometry.dispose();
-            if (e.material) {
-                if (Array.isArray(e.material)) {
-                    e.material.forEach((m: THREE.Material) => m.dispose());
-                } else {
-                    e.material.dispose();
-                }
-            }
-        });
-        this.edgeHighlights = [];
-    }
-    this.clearNormalHelper();
+    this.visualization.reset();
     
     if (this.originalCube && this.originalCube.cubeMesh) {
         this.originalCube.cubeMesh.visible = true;
@@ -1342,257 +1135,7 @@ export class Cutter {
     outlineRefs: IntersectionPoint[];
     cutPlane: THREE.Plane;
   } | null {
-    if (!solid || !snapIds || snapIds.length < 3 || !resolver) return null;
     this.lastTopologyIndex = topologyIndex;
-
-    const resolvedPoints = snapIds
-      .map(id => resolver.resolveSnapPoint(id))
-      .filter((p: THREE.Vector3 | null): p is THREE.Vector3 => p !== null);
-    if (resolvedPoints.length < 3) return null;
-
-    const plane = new THREE.Plane();
-    let validPlane = false;
-    for (let i = 0; i < resolvedPoints.length; i++) {
-      for (let j = i + 1; j < resolvedPoints.length; j++) {
-        for (let k = j + 1; k < resolvedPoints.length; k++) {
-          try {
-            plane.setFromCoplanarPoints(resolvedPoints[i], resolvedPoints[j], resolvedPoints[k]);
-            if (plane.normal.lengthSq() > 0.0001) {
-              validPlane = true;
-              break;
-            }
-          } catch (e) { continue; }
-        }
-        if (validPlane) break;
-      }
-      if (validPlane) break;
-    }
-    if (!validPlane) return null;
-
-    const intersections: THREE.Vector3[] = resolvedPoints.slice();
-    const intersectionRefs: IntersectionPoint[] = [];
-    
-    snapIds.forEach(snapId => {
-      const parsed = normalizeSnapPointId(parseSnapPointId(snapId));
-      if (!parsed) return;
-      const normalizedId = stringifySnapPointId(parsed);
-      if (!normalizedId) return;
-      intersectionRefs.push({
-        id: canonicalizeSnapPointId(normalizedId) || normalizedId,
-        type: 'snap'
-      });
-    });
-
-    let edgesData: any[] = [];
-    const isSSOT = this.isSolidSSOT(solid);
-    if (isSSOT) {
-        edgesData = Object.values((solid as SolidSSOT).edges);
-    } else {
-        edgesData = solid.edges || [];
-    }
-
-    const edgeLines = edgesData.map((edge: any) => {
-        const edgeId = typeof edge === 'string' ? edge : edge.id;
-        const resolved = resolver.resolveEdge(edgeId);
-        return resolved ? new THREE.Line3(resolved.start, resolved.end) : null;
-    });
-
-    edgesData.forEach((edge: any, index: number) => {
-        const line = edgeLines[index];
-        if (!line) return;
-        const target = new THREE.Vector3();
-        if (plane.intersectLine(line, target)) {
-             const distToStart = target.distanceTo(line.start);
-             const distToEnd = target.distanceTo(line.end);
-             const edgeLength = line.distance();
-             if (Math.abs((distToStart + distToEnd) - edgeLength) < 1e-3) {
-                 if (!intersections.some(v => v.distanceTo(target) < 1e-2)) {
-                     intersections.push(target.clone());
-                     const ratioRaw = distToStart / edgeLength;
-                     const denominator = 1000;
-                     const numerator = Math.max(0, Math.min(denominator, Math.round(ratioRaw * denominator)));
-                     const edgeId = typeof edge === 'string' ? edge : edge.id;
-                     const parsed = normalizeSnapPointId({
-                         type: 'edge',
-                         edgeIndex: edgeId.replace(/^E:/, ''),
-                         ratio: { numerator, denominator }
-                     });
-                     const snapId = parsed ? stringifySnapPointId(parsed) : null;
-                     if (snapId) {
-                         const id = canonicalizeSnapPointId(snapId) || snapId;
-                         if (!intersectionRefs.some(ref => ref.id === id)) {
-                             intersectionRefs.push({
-                                 id,
-                                 type: 'intersection',
-                                 edgeId,
-                                 ratio: (parsed && parsed.type === 'edge' ? parsed.ratio : undefined) as Ratio | undefined
-                             });
-                         }
-                     }
-                 }
-             }
-        }
-    });
-
-    const resolveFaceIds = (ref: IntersectionPoint) => {
-        if (ref.faceIds && ref.faceIds.length) return ref.faceIds;
-        const foundFaces: string[] = [];
-        if (ref.edgeId) {
-            if (solid.meta && solid.edges && topologyIndex) { // SSOT
-                const edgeFaces = topologyIndex.edgeToFaces[ref.edgeId];
-                if (edgeFaces && edgeFaces.length) return edgeFaces.slice();
-            } else {
-                const facesList = Array.isArray(solid.faces) ? solid.faces : Object.values(solid.faces);
-                facesList.forEach((face: any) => {
-                     if (solid.meta && solid.edges) { // SSOT
-                         const edge = solid.edges[ref.edgeId!];
-                         if (edge && face.vertices) {
-                             for(let i=0; i<face.vertices.length; i++) {
-                                 const v0 = face.vertices[i];
-                                 const v1 = face.vertices[(i+1)%face.vertices.length];
-                                 if ((edge.v0 === v0 && edge.v1 === v1) || (edge.v0 === v1 && edge.v1 === v0)) {
-                                     foundFaces.push(face.id);
-                                     break;
-                                 }
-                             }
-                         }
-                     } else { // Legacy
-                         const edgeIds = Array.isArray(face.edges) ? face.edges.map((e:any) => typeof e === 'string'?e:e.id) : [];
-                         if (edgeIds.includes(ref.edgeId)) foundFaces.push(face.id);
-                     }
-                });
-            }
-        }
-        return foundFaces.length ? foundFaces : undefined;
-    };
-    intersectionRefs.forEach(ref => {
-        if (!ref.faceIds) ref.faceIds = resolveFaceIds(ref);
-    });
-    
-    const keepPositive = true; 
-    const isInside = (dist: number) => keepPositive ? dist >= -1e-5 : dist <= 1e-5;
-    
-    const buildEdgeSnapId = (edgeId: string, t: number, startId: string, endId: string) => {
-        if (t <= 1e-6) return startId;
-        if (t >= 1 - 1e-6) return endId;
-        const found = intersectionRefs.find(r => r.edgeId === edgeId && r.ratio && Math.abs(r.ratio.numerator/r.ratio.denominator - t) < 0.01);
-        if (found) return found.id;
-        const numerator = Math.round(t * 1000);
-        const parsed = normalizeSnapPointId({ type: 'edge', edgeIndex: edgeId.replace(/^E:/, ''), ratio: { numerator, denominator: 1000 } });
-        return parsed ? stringifySnapPointId(parsed) : null;
-    };
-
-    const polygons: CutFacePolygon[] = [];
-    const facesData = isSSOT ? Object.values((solid as SolidSSOT).faces) : (Array.isArray(solid.faces) ? solid.faces : Object.values(solid.faces));
-    
-    facesData.forEach((face: any) => {
-        let vertices: any[] = [];
-        let edgeIds: string[] = [];
-
-        if (isSSOT) {
-             vertices = (face.vertices as string[]).map(vid => ({ id: vid, position: resolver.resolveVertex(vid) }));
-             const vIds = face.vertices;
-             for(let i=0; i<vIds.length; i++) {
-                 const v0 = vIds[i];
-                 const v1 = vIds[(i+1)%vIds.length];
-                 const edgeId = this.resolveEdgeIdFromVertices(solid as SolidSSOT, v0, v1, topologyIndex);
-                 if (edgeId) edgeIds.push(edgeId);
-             }
-        } else {
-             vertices = (face.vertices as any[]).map((v: any) => {
-                const id = typeof v === 'string' ? v : v.id;
-                return { id, position: resolver.resolveVertex(id) };
-             });
-             edgeIds = Array.isArray(face.edges) ? face.edges.map((e:any) => typeof e === 'string'?e:e.id) : [];
-        }
-
-        vertices = vertices.filter((v:any) => v.position);
-        if (vertices.length < 3 || edgeIds.length !== vertices.length) return;
-
-        const output: any[] = [];
-        for (let i = 0; i < vertices.length; i++) {
-            const current = vertices[i];
-            const next = vertices[(i + 1) % vertices.length];
-            const edgeId = edgeIds[i];
-            const d1 = plane.distanceToPoint(current.position);
-            const d2 = plane.distanceToPoint(next.position);
-            const inside1 = isInside(d1);
-            const inside2 = isInside(d2);
-
-            if (inside1 && inside2) {
-                output.push(next);
-            } else if (inside1 && !inside2) {
-                const t = d1 / (d1 - d2);
-                const snapId = buildEdgeSnapId(edgeId, t, current.id, next.id);
-                if (snapId) {
-                     const pos = current.position.clone().lerp(next.position, t);
-                     output.push({ id: snapId, position: pos });
-                }
-            } else if (!inside1 && inside2) {
-                const t = d1 / (d1 - d2);
-                const snapId = buildEdgeSnapId(edgeId, t, current.id, next.id);
-                if (snapId) {
-                     const pos = current.position.clone().lerp(next.position, t);
-                     output.push({ id: snapId, position: pos });
-                }
-                output.push(next);
-            }
-        }
-        
-        if (output.length >= 3) {
-            const unique = output.filter((v, i, a) => i === 0 || v.id !== a[i-1].id);
-            if (unique.length > 0 && unique[0].id === unique[unique.length-1].id) unique.pop();
-            
-            if (unique.length >= 3) {
-                 polygons.push({
-                     faceId: face.id,
-                     type: 'original',
-                     vertexIds: unique.map(v => v.id)
-                 });
-            }
-        }
-    });
-
-    const cutPoints = intersectionRefs.map(ref => ({ ref, pos: resolver.resolveSnapPoint(ref.id) })).filter((p): p is { ref: IntersectionPoint, pos: THREE.Vector3 } => p.pos !== null);
-    if (cutPoints.length >= 3) {
-        const center = new THREE.Vector3();
-        cutPoints.forEach(p => center.add(p.pos));
-        center.divideScalar(cutPoints.length);
-        const normal = plane.normal;
-        const base = new THREE.Vector3().subVectors(cutPoints[0].pos, center).normalize();
-        const up = new THREE.Vector3().crossVectors(normal, base).normalize();
-        
-        cutPoints.sort((a, b) => {
-             const va = new THREE.Vector3().subVectors(a.pos, center);
-             const vb = new THREE.Vector3().subVectors(b.pos, center);
-             return Math.atan2(va.dot(up), va.dot(base)) - Math.atan2(vb.dot(up), vb.dot(base));
-        });
-        
-        const cutVertexIds = cutPoints.map(p => p.ref.id);
-        const cutFaceId = `F:${cutVertexIds.join('-')}`;
-        
-        polygons.push({
-            faceId: cutFaceId,
-            type: 'cut',
-            vertexIds: cutVertexIds
-        });
-    }
-
-    const cutSegments: CutSegmentMeta[] = cutPoints.map((p, i) => ({
-        startId: p.ref.id,
-        endId: cutPoints[(i+1)%cutPoints.length].ref.id,
-        faceIds: [] as string[]
-    }));
-    
-    const faceAdjacency = buildFaceAdjacency(polygons); 
-
-    return {
-        intersections: intersectionRefs,
-        facePolygons: polygons,
-        faceAdjacency,
-        cutSegments,
-        outlineRefs: cutPoints.map(p => p.ref),
-        cutPlane: plane
-    };
+    return computeCutState(solid, snapIds, resolver, topologyIndex);
   }
 }

--- a/js/cutter/CutCSG.ts
+++ b/js/cutter/CutCSG.ts
@@ -1,0 +1,117 @@
+import * as THREE from 'three';
+import { SUBTRACTION, INTERSECTION, Brush, Evaluator } from 'three-bvh-csg';
+import type { SolidSSOT } from '../model/objectModel.js';
+
+export type CutCSGResult = {
+  resultMesh: THREE.Mesh;
+  removedMesh: THREE.Mesh;
+};
+
+const isSolidSSOT = (solid: any): solid is SolidSSOT => {
+  return !!(solid && solid.meta && solid.vertices && typeof solid.getStructure !== 'function');
+};
+
+export class CutCSG {
+  evaluator: Evaluator;
+
+  constructor() {
+    this.evaluator = new Evaluator();
+    this.evaluator.attributes = ['position', 'normal'];
+    this.evaluator.useGroups = true;
+  }
+
+  applyCut({
+    cube,
+    plane,
+    planePoint,
+    cutNegative,
+    isTransparent,
+    scene
+  }: {
+    cube: any;
+    plane: THREE.Plane;
+    planePoint: THREE.Vector3;
+    cutNegative: boolean;
+    isTransparent: boolean;
+    scene: THREE.Scene;
+  }): CutCSGResult | null {
+    const normal = plane.normal.clone();
+    if (cutNegative) normal.negate();
+
+    const sizeBase = (() => {
+      if (isSolidSSOT(cube)) {
+        const { lx, ly, lz } = cube.meta.size;
+        return Math.max(lx, ly, lz);
+      }
+      if (typeof cube.size === 'number') return cube.size;
+      return 10;
+    })();
+
+    const size = sizeBase * 5;
+    const geom = new THREE.BoxGeometry(size, size, size);
+    const cutBrush = new (Brush as any)(geom) as any;
+
+    const centerOffset = normal.clone().multiplyScalar(size / 2);
+    const brushPos = planePoint.clone().add(centerOffset);
+    cutBrush.position.copy(brushPos);
+
+    const defaultUp = new THREE.Vector3(0, 1, 0);
+    const quaternion = new THREE.Quaternion().setFromUnitVectors(defaultUp, normal);
+    cutBrush.setRotationFromQuaternion(quaternion);
+    cutBrush.updateMatrixWorld();
+
+    let cubeBrush: any;
+    let cubeMat: THREE.Material;
+
+    if (isSolidSSOT(cube)) {
+      const { lx, ly, lz } = cube.meta.size;
+      const geometry = new THREE.BoxGeometry(lx, ly, lz);
+      cubeBrush = new (Brush as any)(geometry) as any;
+      cubeBrush.updateMatrixWorld();
+
+      cubeMat = new THREE.MeshBasicMaterial({ color: 0xffffff });
+      cubeMat.side = THREE.DoubleSide;
+      cubeMat.transparent = isTransparent;
+      cubeMat.opacity = isTransparent ? 0.4 : 1.0;
+      cubeMat.depthWrite = !isTransparent;
+    } else {
+      cubeBrush = new (Brush as any)(cube.cubeMesh.geometry.clone()) as any;
+      cubeBrush.position.copy(cube.cubeMesh.position);
+      cubeBrush.rotation.copy(cube.cubeMesh.rotation);
+      cubeBrush.scale.copy(cube.cubeMesh.scale);
+      cubeBrush.updateMatrixWorld();
+
+      cubeMat = cube.cubeMesh.material.clone();
+      cubeMat.side = THREE.DoubleSide;
+      cubeMat.transparent = isTransparent;
+      cubeMat.opacity = isTransparent ? 0.4 : 1.0;
+      cubeMat.depthWrite = !isTransparent;
+    }
+
+    const cutMat = new THREE.MeshBasicMaterial({
+      color: 0xffcccc,
+      side: THREE.DoubleSide,
+      depthTest: true,
+      polygonOffset: true,
+      polygonOffsetFactor: 1,
+      polygonOffsetUnits: 1,
+      transparent: true,
+      opacity: 0.5,
+      depthWrite: false,
+      name: 'cutFace'
+    });
+
+    cubeBrush.material = cubeMat;
+    cutBrush.material = cutMat;
+
+    const resultMesh = this.evaluator.evaluate(cubeBrush, cutBrush, SUBTRACTION) as THREE.Mesh;
+    resultMesh.material = [cubeMat, cutMat];
+    scene.add(resultMesh);
+
+    const removedMesh = this.evaluator.evaluate(cubeBrush, cutBrush, INTERSECTION) as THREE.Mesh;
+    removedMesh.material = [cubeMat, cutMat];
+    scene.add(removedMesh);
+
+    return { resultMesh, removedMesh };
+  }
+}

--- a/js/cutter/CutComputation.ts
+++ b/js/cutter/CutComputation.ts
@@ -1,0 +1,301 @@
+import * as THREE from 'three';
+import { buildFaceAdjacency } from './cutFaceGraph.js';
+import { canonicalizeSnapPointId, normalizeSnapPointId, parseSnapPointId, stringifySnapPointId } from '../geometry/snapPointId.js';
+import type { CutFacePolygon, CutSegmentMeta, IntersectionPoint, Ratio, SnapPointID } from '../types.js';
+import type { ObjectCutAdjacency, SolidSSOT, TopologyIndex } from '../model/objectModel.js';
+
+const isSolidSSOT = (solid: any): solid is SolidSSOT => {
+  return !!(solid && solid.meta && solid.vertices && typeof solid.getStructure !== 'function');
+};
+
+const resolveEdgeIdFromVertices = (
+  solid: SolidSSOT,
+  v0: string,
+  v1: string,
+  topologyIndex: TopologyIndex | null
+): string | null => {
+  if (topologyIndex) {
+    const edgeIds = topologyIndex.vertexToEdges[v0] || [];
+    for (let i = 0; i < edgeIds.length; i++) {
+      const edge = solid.edges[edgeIds[i]];
+      if (!edge) continue;
+      if ((edge.v0 === v0 && edge.v1 === v1) || (edge.v0 === v1 && edge.v1 === v0)) {
+        return edge.id;
+      }
+    }
+    return null;
+  }
+  const edges = Object.values(solid.edges);
+  const match = edges.find((edge: any) =>
+    (edge.v0 === v0 && edge.v1 === v1) || (edge.v0 === v1 && edge.v1 === v0)
+  );
+  return match ? match.id : null;
+};
+
+export const computeCutState = (
+  solid: SolidSSOT | any,
+  snapIds: SnapPointID[],
+  resolver: any,
+  topologyIndex: TopologyIndex | null = null
+): {
+  intersections: IntersectionPoint[];
+  facePolygons: CutFacePolygon[];
+  faceAdjacency: ObjectCutAdjacency[];
+  cutSegments: CutSegmentMeta[];
+  outlineRefs: IntersectionPoint[];
+  cutPlane: THREE.Plane;
+} | null => {
+  if (!solid || !snapIds || snapIds.length < 3 || !resolver) return null;
+
+  const resolvedPoints = snapIds
+    .map(id => resolver.resolveSnapPoint(id))
+    .filter((p: THREE.Vector3 | null): p is THREE.Vector3 => p !== null);
+  if (resolvedPoints.length < 3) return null;
+
+  const plane = new THREE.Plane();
+  let validPlane = false;
+  for (let i = 0; i < resolvedPoints.length; i++) {
+    for (let j = i + 1; j < resolvedPoints.length; j++) {
+      for (let k = j + 1; k < resolvedPoints.length; k++) {
+        try {
+          plane.setFromCoplanarPoints(resolvedPoints[i], resolvedPoints[j], resolvedPoints[k]);
+          if (plane.normal.lengthSq() > 0.0001) {
+            validPlane = true;
+            break;
+          }
+        } catch (e) { continue; }
+      }
+      if (validPlane) break;
+    }
+    if (validPlane) break;
+  }
+  if (!validPlane) return null;
+
+  const intersections: THREE.Vector3[] = resolvedPoints.slice();
+  const intersectionRefs: IntersectionPoint[] = [];
+
+  snapIds.forEach(snapId => {
+    const parsed = normalizeSnapPointId(parseSnapPointId(snapId));
+    if (!parsed) return;
+    const normalizedId = stringifySnapPointId(parsed);
+    if (!normalizedId) return;
+    intersectionRefs.push({
+      id: canonicalizeSnapPointId(normalizedId) || normalizedId,
+      type: 'snap'
+    });
+  });
+
+  let edgesData: any[] = [];
+  const isSSOT = isSolidSSOT(solid);
+  if (isSSOT) {
+    edgesData = Object.values((solid as SolidSSOT).edges);
+  } else {
+    edgesData = solid.edges || [];
+  }
+
+  const edgeLines = edgesData.map((edge: any) => {
+    const edgeId = typeof edge === 'string' ? edge : edge.id;
+    const resolved = resolver.resolveEdge(edgeId);
+    return resolved ? new THREE.Line3(resolved.start, resolved.end) : null;
+  });
+
+  edgesData.forEach((edge: any, index: number) => {
+    const line = edgeLines[index];
+    if (!line) return;
+    const target = new THREE.Vector3();
+    if (plane.intersectLine(line, target)) {
+      const distToStart = target.distanceTo(line.start);
+      const distToEnd = target.distanceTo(line.end);
+      const edgeLength = line.distance();
+      if (Math.abs((distToStart + distToEnd) - edgeLength) < 1e-3) {
+        if (!intersections.some(v => v.distanceTo(target) < 1e-2)) {
+          intersections.push(target.clone());
+          const ratioRaw = distToStart / edgeLength;
+          const denominator = 1000;
+          const numerator = Math.max(0, Math.min(denominator, Math.round(ratioRaw * denominator)));
+          const edgeId = typeof edge === 'string' ? edge : edge.id;
+          const parsed = normalizeSnapPointId({
+            type: 'edge',
+            edgeIndex: edgeId.replace(/^E:/, ''),
+            ratio: { numerator, denominator }
+          });
+          const snapId = parsed ? stringifySnapPointId(parsed) : null;
+          if (snapId) {
+            const id = canonicalizeSnapPointId(snapId) || snapId;
+            if (!intersectionRefs.some(ref => ref.id === id)) {
+              intersectionRefs.push({
+                id,
+                type: 'intersection',
+                edgeId,
+                ratio: (parsed && parsed.type === 'edge' ? parsed.ratio : undefined) as Ratio | undefined
+              });
+            }
+          }
+        }
+      }
+    }
+  });
+
+  const resolveFaceIds = (ref: IntersectionPoint) => {
+    if (ref.faceIds && ref.faceIds.length) return ref.faceIds;
+    const foundFaces: string[] = [];
+    if (ref.edgeId) {
+      if (solid.meta && solid.edges && topologyIndex) {
+        const edgeFaces = topologyIndex.edgeToFaces[ref.edgeId];
+        if (edgeFaces && edgeFaces.length) return edgeFaces.slice();
+      } else {
+        const facesList = Array.isArray(solid.faces) ? solid.faces : Object.values(solid.faces);
+        facesList.forEach((face: any) => {
+          if (solid.meta && solid.edges) {
+            const edge = solid.edges[ref.edgeId!];
+            if (edge && face.vertices) {
+              for (let i = 0; i < face.vertices.length; i++) {
+                const v0 = face.vertices[i];
+                const v1 = face.vertices[(i + 1) % face.vertices.length];
+                if ((edge.v0 === v0 && edge.v1 === v1) || (edge.v0 === v1 && edge.v1 === v0)) {
+                  foundFaces.push(face.id);
+                  break;
+                }
+              }
+            }
+          } else {
+            const edgeIds = Array.isArray(face.edges) ? face.edges.map((e: any) => typeof e === 'string' ? e : e.id) : [];
+            if (edgeIds.includes(ref.edgeId)) foundFaces.push(face.id);
+          }
+        });
+      }
+    }
+    return foundFaces.length ? foundFaces : undefined;
+  };
+  intersectionRefs.forEach(ref => {
+    if (!ref.faceIds) ref.faceIds = resolveFaceIds(ref);
+  });
+
+  const keepPositive = true;
+  const isInside = (dist: number) => keepPositive ? dist >= -1e-5 : dist <= 1e-5;
+
+  const buildEdgeSnapId = (edgeId: string, t: number, startId: string, endId: string) => {
+    if (t <= 1e-6) return startId;
+    if (t >= 1 - 1e-6) return endId;
+    const found = intersectionRefs.find(r => r.edgeId === edgeId && r.ratio && Math.abs(r.ratio.numerator / r.ratio.denominator - t) < 0.01);
+    if (found) return found.id;
+    const numerator = Math.round(t * 1000);
+    const parsed = normalizeSnapPointId({ type: 'edge', edgeIndex: edgeId.replace(/^E:/, ''), ratio: { numerator, denominator: 1000 } });
+    return parsed ? stringifySnapPointId(parsed) : null;
+  };
+
+  const polygons: CutFacePolygon[] = [];
+  const facesData = isSSOT ? Object.values((solid as SolidSSOT).faces) : (Array.isArray(solid.faces) ? solid.faces : Object.values(solid.faces));
+
+  facesData.forEach((face: any) => {
+    let vertices: any[] = [];
+    let edgeIds: string[] = [];
+
+    if (isSSOT) {
+      vertices = (face.vertices as string[]).map(vid => ({ id: vid, position: resolver.resolveVertex(vid) }));
+      const vIds = face.vertices;
+      for (let i = 0; i < vIds.length; i++) {
+        const v0 = vIds[i];
+        const v1 = vIds[(i + 1) % vIds.length];
+        const edgeId = resolveEdgeIdFromVertices(solid as SolidSSOT, v0, v1, topologyIndex);
+        if (edgeId) edgeIds.push(edgeId);
+      }
+    } else {
+      vertices = (face.vertices as any[]).map((v: any) => {
+        const id = typeof v === 'string' ? v : v.id;
+        return { id, position: resolver.resolveVertex(id) };
+      });
+      edgeIds = Array.isArray(face.edges) ? face.edges.map((e: any) => typeof e === 'string' ? e : e.id) : [];
+    }
+
+    vertices = vertices.filter((v: any) => v.position);
+    if (vertices.length < 3 || edgeIds.length !== vertices.length) return;
+
+    const output: any[] = [];
+    for (let i = 0; i < vertices.length; i++) {
+      const current = vertices[i];
+      const next = vertices[(i + 1) % vertices.length];
+      const edgeId = edgeIds[i];
+      const d1 = plane.distanceToPoint(current.position);
+      const d2 = plane.distanceToPoint(next.position);
+      const inside1 = isInside(d1);
+      const inside2 = isInside(d2);
+
+      if (inside1 && inside2) {
+        output.push(next);
+      } else if (inside1 && !inside2) {
+        const t = d1 / (d1 - d2);
+        const snapId = buildEdgeSnapId(edgeId, t, current.id, next.id);
+        if (snapId) {
+          const pos = current.position.clone().lerp(next.position, t);
+          output.push({ id: snapId, position: pos });
+        }
+      } else if (!inside1 && inside2) {
+        const t = d1 / (d1 - d2);
+        const snapId = buildEdgeSnapId(edgeId, t, current.id, next.id);
+        if (snapId) {
+          const pos = current.position.clone().lerp(next.position, t);
+          output.push({ id: snapId, position: pos });
+        }
+        output.push(next);
+      }
+    }
+
+    if (output.length >= 3) {
+      const unique = output.filter((v, i, a) => i === 0 || v.id !== a[i - 1].id);
+      if (unique.length > 0 && unique[0].id === unique[unique.length - 1].id) unique.pop();
+
+      if (unique.length >= 3) {
+        polygons.push({
+          faceId: face.id,
+          type: 'original',
+          vertexIds: unique.map(v => v.id)
+        });
+      }
+    }
+  });
+
+  const cutPoints = intersectionRefs
+    .map(ref => ({ ref, pos: resolver.resolveSnapPoint(ref.id) }))
+    .filter((p): p is { ref: IntersectionPoint; pos: THREE.Vector3 } => p.pos !== null);
+  if (cutPoints.length >= 3) {
+    const center = new THREE.Vector3();
+    cutPoints.forEach(p => center.add(p.pos));
+    center.divideScalar(cutPoints.length);
+    const normal = plane.normal;
+    const base = new THREE.Vector3().subVectors(cutPoints[0].pos, center).normalize();
+    const up = new THREE.Vector3().crossVectors(normal, base).normalize();
+
+    cutPoints.sort((a, b) => {
+      const va = new THREE.Vector3().subVectors(a.pos, center);
+      const vb = new THREE.Vector3().subVectors(b.pos, center);
+      return Math.atan2(va.dot(up), va.dot(base)) - Math.atan2(vb.dot(up), vb.dot(base));
+    });
+
+    const cutVertexIds = cutPoints.map(p => p.ref.id);
+    const cutFaceId = `F:${cutVertexIds.join('-')}`;
+
+    polygons.push({
+      faceId: cutFaceId,
+      type: 'cut',
+      vertexIds: cutVertexIds
+    });
+  }
+
+  const cutSegments: CutSegmentMeta[] = cutPoints.map((p, i) => ({
+    startId: p.ref.id,
+    endId: cutPoints[(i + 1) % cutPoints.length].ref.id,
+    faceIds: [] as string[]
+  }));
+
+  const faceAdjacency = buildFaceAdjacency(polygons);
+
+  return {
+    intersections: intersectionRefs,
+    facePolygons: polygons,
+    faceAdjacency,
+    cutSegments,
+    outlineRefs: cutPoints.map(p => p.ref),
+    cutPlane: plane
+  };
+};

--- a/js/cutter/CutVisualization.ts
+++ b/js/cutter/CutVisualization.ts
@@ -1,0 +1,251 @@
+import * as THREE from 'three';
+import { VertexNormalsHelper } from 'three/examples/jsm/helpers/VertexNormalsHelper.js';
+import { createMarker } from '../utils.js';
+import type { IntersectionPoint } from '../types.js';
+
+export type EdgeHighlightMeta = {
+  edgeId: string;
+  hasMidpoint: boolean;
+};
+
+export class CutVisualization {
+  scene: THREE.Scene;
+  cutOverlayGroup: THREE.Group | null;
+  outline: THREE.Line | null;
+  cutLineMaterial: THREE.LineBasicMaterial | null;
+  vertexMarkers: THREE.Object3D[];
+  edgeHighlights: THREE.Object3D[];
+  normalHelper: VertexNormalsHelper | null;
+  showNormalHelper: boolean;
+  showCutPoints: boolean;
+  colorizeCutLines: boolean;
+  cutLineDefaultColor: number;
+  cutLineHighlightColor: number;
+  edgeHighlightColorResolver: ((edgeId: string) => number) | null;
+  visible: boolean;
+
+  constructor(scene: THREE.Scene) {
+    this.scene = scene;
+    this.cutOverlayGroup = null;
+    this.outline = null;
+    this.cutLineMaterial = null;
+    this.vertexMarkers = [];
+    this.edgeHighlights = [];
+    this.normalHelper = null;
+    this.showNormalHelper = false;
+    this.showCutPoints = true;
+    this.colorizeCutLines = false;
+    this.cutLineDefaultColor = 0x444444;
+    this.cutLineHighlightColor = 0xff0000;
+    this.edgeHighlightColorResolver = null;
+    this.visible = true;
+  }
+
+  setVisible(visible: boolean) {
+    this.visible = !!visible;
+    if (this.outline) this.outline.visible = this.visible;
+    if (this.normalHelper) this.normalHelper.visible = this.visible;
+    this.edgeHighlights.forEach(edge => { edge.visible = this.visible; });
+    this.setCutPointsVisible(this.showCutPoints);
+  }
+
+  ensureCutOverlayGroup() {
+    if (this.cutOverlayGroup) return;
+    this.cutOverlayGroup = new THREE.Group();
+    this.scene.add(this.cutOverlayGroup);
+  }
+
+  clearNormalHelper() {
+    if (!this.normalHelper) return;
+    this.scene.remove(this.normalHelper);
+    const helper = this.normalHelper as any;
+    if (helper.geometry) helper.geometry.dispose();
+    if (helper.material) helper.material.dispose();
+    this.normalHelper = null;
+  }
+
+  refreshNormalHelper(mesh: THREE.Mesh) {
+    if (!this.showNormalHelper) return;
+    this.clearNormalHelper();
+    const helper = new VertexNormalsHelper(mesh, 0.6, 0x990000);
+    helper.visible = this.visible;
+    this.scene.add(helper);
+    this.normalHelper = helper;
+    helper.update();
+  }
+
+  setShowNormalHelper(visible: boolean, mesh: THREE.Mesh | null) {
+    this.showNormalHelper = !!visible;
+    if (!this.showNormalHelper) {
+      this.clearNormalHelper();
+      return;
+    }
+    if (mesh) {
+      this.refreshNormalHelper(mesh);
+    }
+  }
+
+  setCutPointsVisible(visible: boolean) {
+    this.showCutPoints = !!visible;
+    const next = this.visible && this.showCutPoints;
+    this.vertexMarkers.forEach(marker => { marker.visible = next; });
+  }
+
+  getCutPointsVisible() {
+    return this.showCutPoints;
+  }
+
+  clearCutPointMarkers() {
+    if (!this.vertexMarkers) return;
+    this.vertexMarkers.forEach(marker => {
+      if (this.cutOverlayGroup) {
+        this.cutOverlayGroup.remove(marker);
+      } else {
+        this.scene.remove(marker);
+      }
+      const m = marker as any;
+      if (m.geometry) m.geometry.dispose();
+    });
+    this.vertexMarkers = [];
+  }
+
+  addMarker(position: THREE.Vector3, color: number, isMidpoint: boolean) {
+    this.ensureCutOverlayGroup();
+    const marker = createMarker(position, this.scene, color, isMidpoint, this.cutOverlayGroup || undefined);
+    this.vertexMarkers.push(marker);
+    marker.visible = this.visible && this.showCutPoints;
+  }
+
+  updateCutPointMarkers(intersections: IntersectionPoint[], resolver: any) {
+    this.clearCutPointMarkers();
+    if (!intersections || !intersections.length) return;
+    const selectionIds = new Set(
+      intersections
+        .filter(ref => ref.type === 'snap' && ref.id)
+        .map(ref => ref.id)
+    );
+    intersections
+      .filter(ref => ref.type === 'intersection' && ref.id)
+      .forEach(ref => {
+        if (selectionIds.has(ref.id)) return;
+        const position = resolver.resolveSnapPoint(ref.id);
+        if (!(position instanceof THREE.Vector3)) return;
+        const markerColor = 0xffff00;
+        this.addMarker(position.clone(), markerColor, false);
+      });
+    this.setCutPointsVisible(this.showCutPoints);
+  }
+
+  setCutLineColorize(enabled: boolean) {
+    this.colorizeCutLines = !!enabled;
+    this.refreshEdgeHighlightColors();
+    if (this.cutLineMaterial) {
+      this.cutLineMaterial.color.setHex(
+        this.colorizeCutLines ? this.cutLineHighlightColor : this.cutLineDefaultColor
+      );
+      this.cutLineMaterial.needsUpdate = true;
+    }
+  }
+
+  setEdgeHighlightColorResolver(resolver: ((edgeId: string) => number) | null) {
+    this.edgeHighlightColorResolver = resolver || null;
+    this.refreshEdgeHighlightColors();
+  }
+
+  refreshEdgeHighlightColors() {
+    this.edgeHighlights.forEach(edge => {
+      edge.visible = this.visible;
+      const edgeId = edge.userData ? edge.userData.edgeId : null;
+      const material = (edge as THREE.Line).material;
+      if (!(material instanceof THREE.LineBasicMaterial)) return;
+      let color = this.cutLineDefaultColor;
+      if (this.colorizeCutLines && this.edgeHighlightColorResolver && typeof edgeId === 'string') {
+        color = this.edgeHighlightColorResolver(edgeId);
+      }
+      material.color.setHex(color);
+      material.needsUpdate = true;
+    });
+  }
+
+  updateOutline(points: THREE.Vector3[]) {
+    if (!points.length) return;
+    const linePoints = [...points, points[0]];
+    const lineGeo = new THREE.BufferGeometry().setFromPoints(linePoints);
+    if (this.outline) {
+      this.outline.geometry.dispose();
+      this.outline.geometry = lineGeo;
+      return;
+    }
+    this.ensureCutOverlayGroup();
+    this.cutLineMaterial = new THREE.LineBasicMaterial({
+      color: this.colorizeCutLines ? this.cutLineHighlightColor : this.cutLineDefaultColor,
+      linewidth: 2
+    });
+    this.outline = new THREE.Line(lineGeo, this.cutLineMaterial);
+    this.outline.visible = this.visible;
+    if (this.cutOverlayGroup) {
+      this.cutOverlayGroup.add(this.outline);
+    }
+  }
+
+  clearOutline() {
+    if (!this.outline) return;
+    if (this.cutOverlayGroup) {
+      this.cutOverlayGroup.remove(this.outline);
+    } else {
+      this.scene.remove(this.outline);
+    }
+    this.outline.geometry.dispose();
+    const mat = this.outline.material;
+    if (Array.isArray(mat)) {
+      mat.forEach(m => m.dispose());
+    } else {
+      mat.dispose();
+    }
+    this.outline = null;
+    this.cutLineMaterial = null;
+  }
+
+  clearEdgeHighlights() {
+    this.edgeHighlights.forEach(edge => {
+      this.scene.remove(edge);
+      const e = edge as any;
+      if (e.geometry) e.geometry.dispose();
+      if (e.material) {
+        if (Array.isArray(e.material)) {
+          e.material.forEach((m: THREE.Material) => m.dispose());
+        } else {
+          e.material.dispose();
+        }
+      }
+    });
+    this.edgeHighlights = [];
+  }
+
+  updateEdgeHighlights(edgeIds: EdgeHighlightMeta[], resolver: any) {
+    this.clearEdgeHighlights();
+    edgeIds.forEach(meta => {
+      const resolved = resolver.resolveEdge(meta.edgeId);
+      if (!resolved) return;
+      const geometry = new THREE.BufferGeometry().setFromPoints([resolved.start, resolved.end]);
+      const material = new THREE.LineBasicMaterial({ color: this.cutLineDefaultColor });
+      const line = new THREE.Line(geometry, material);
+      line.userData = { type: 'education-edge', edgeId: meta.edgeId, hasMidpoint: !!meta.hasMidpoint };
+      line.visible = this.visible;
+      this.scene.add(line);
+      this.edgeHighlights.push(line);
+    });
+    this.refreshEdgeHighlightColors();
+  }
+
+  reset() {
+    this.clearNormalHelper();
+    this.clearCutPointMarkers();
+    this.clearOutline();
+    if (this.cutOverlayGroup) {
+      this.scene.remove(this.cutOverlayGroup);
+      this.cutOverlayGroup = null;
+    }
+    this.clearEdgeHighlights();
+  }
+}


### PR DESCRIPTION
Closes #140

## 概要
- CutComputation / CutVisualization / CutCSG を新設
- Cutter を orchestrator 化し、責務を分離

## 経緯
- Cutter が交点計算/断面生成/可視化/CSG を一括で担っていたため分離

## 実装上の留意点
- API 互換を維持し、内部実装のみ分割
- 可視化は CutVisualization に集約
- CSG は CutCSG で評価
- 計算は CutComputation に移譲

## レビューしてほしい点
- 分離後の責務境界と依存の妥当性
- 既存 API への影響

## テスト
- `npm run typecheck`
- `npx vitest run`
- `npm run build`

## L2 ドキュメント
- なし

## リファクタリング前の状態
- Cutter が計算/可視化/CSG を一括で担当

## リファクタリング後の状態
- CutComputation / CutVisualization / CutCSG に分離し、Cutter は orchestrator
