### PR TITLE
[#141] main の cut 実行フローのサービス化

### DIFF
--- a/js/Cutter.ts
+++ b/js/Cutter.ts
@@ -52,6 +52,26 @@ export class Cutter {
     this.visible = true;
   }
 
+  get evaluator() {
+    return this.csg.evaluator;
+  }
+
+  get outline() {
+    return this.visualization.outline;
+  }
+
+  set outline(value: THREE.Line | null) {
+    this.visualization.outline = value;
+  }
+
+  get vertexMarkers() {
+    return this.visualization.vertexMarkers;
+  }
+
+  set vertexMarkers(value: THREE.Object3D[]) {
+    this.visualization.vertexMarkers = value;
+  }
+
   setDebug(debug: boolean) {
     this.debug = !!debug;
   }

--- a/js/cutter/CutService.ts
+++ b/js/cutter/CutService.ts
@@ -1,0 +1,119 @@
+import type { ObjectModelManager } from '../model/objectModelManager.js';
+import type { CutResultMeta, SnapPointID } from '../types.js';
+import type { Cutter } from '../Cutter.js';
+import type { SelectionManager } from '../SelectionManager.js';
+import type { UIManager } from '../UIManager.js';
+import type { GeometryResolver } from '../geometry/GeometryResolver.js';
+import type { SolidSSOT } from '../model/objectModel.js';
+import { generateExplanation } from '../education/explanationGenerator.js';
+
+export class CutService {
+  cutter: Cutter;
+  objectModelManager: ObjectModelManager;
+  selection: SelectionManager;
+  resolver: GeometryResolver;
+  ui: UIManager;
+
+  constructor({
+    cutter,
+    objectModelManager,
+    selection,
+    resolver,
+    ui
+  }: {
+    cutter: Cutter;
+    objectModelManager: ObjectModelManager;
+    selection: SelectionManager;
+    resolver: GeometryResolver;
+    ui: UIManager;
+  }) {
+    this.cutter = cutter;
+    this.objectModelManager = objectModelManager;
+    this.selection = selection;
+    this.resolver = resolver;
+    this.ui = ui;
+  }
+
+  executeCut({ snapIds, structure }: { snapIds?: SnapPointID[]; structure?: any } = {}) {
+    const ids = snapIds && snapIds.length ? snapIds : this.selection.getSelectedSnapIds();
+    if (ids.length < 3) return false;
+
+    const solid = this.objectModelManager.getModel()?.ssot;
+    if (!solid) return false;
+    const topologyIndex = this.objectModelManager.getModel()?.derived.topologyIndex || null;
+
+    const success = this.cutter.cut(solid, ids, this.resolver, { topologyIndex });
+    if (!success) {
+      console.warn("切断処理に失敗しました。点を選択し直してください。");
+      this.selection.reset();
+      return false;
+    }
+
+    this.objectModelManager.applyCutDisplayToView({ cutter: this.cutter });
+    const modelDisplay = this.objectModelManager.getDisplayState();
+    this.cutter.setTransparency(modelDisplay.cubeTransparent);
+
+    const cutState = this.cutter.computeCutState(solid, ids, this.resolver, topologyIndex);
+
+    if (cutState) {
+      this.objectModelManager.syncCutState({
+        intersections: cutState.intersections,
+        cutSegments: cutState.cutSegments,
+        facePolygons: cutState.facePolygons,
+        faceAdjacency: cutState.faceAdjacency
+      });
+    } else {
+      console.warn("Structure-first cut failed, falling back to legacy CSG result.");
+      this.objectModelManager.syncCutState({
+        intersections: this.cutter.getIntersectionRefs(),
+        cutSegments: this.cutter.getCutSegments(),
+        facePolygons: this.cutter.getResultFacePolygons(),
+        faceAdjacency: this.cutter.getResultFaceAdjacency()
+      });
+    }
+
+    const explanation = generateExplanation({
+      snapIds: ids,
+      outlineRefs: this.cutter.getOutlineRefs(),
+      structure: structure || solid
+    });
+    this.ui.setExplanation(explanation);
+
+    return true;
+  }
+
+  syncFromCutterResult(solid: SolidSSOT | null = null) {
+    this.objectModelManager.applyCutDisplayToView({ cutter: this.cutter });
+    const display = this.objectModelManager.getDisplayState();
+    this.cutter.setTransparency(display.cubeTransparent);
+    this.objectModelManager.syncCutState({
+      intersections: this.cutter.getIntersectionRefs(),
+      cutSegments: this.cutter.getCutSegments(),
+      facePolygons: this.cutter.getResultFacePolygons() as any,
+      faceAdjacency: this.cutter.getResultFaceAdjacency()
+    });
+    if (!solid) return;
+    const explanation = generateExplanation({
+      snapIds: this.selection.getSelectedSnapIds(),
+      outlineRefs: this.cutter.getOutlineRefs(),
+      structure: solid
+    });
+    this.ui.setExplanation(explanation);
+  }
+
+  applyCutResultMeta(meta: CutResultMeta, snapIds: SnapPointID[], structure: any) {
+    this.cutter.applyCutResultMeta(meta, this.resolver);
+    this.objectModelManager.syncCutState({
+      intersections: this.cutter.getIntersectionRefs(),
+      cutSegments: this.cutter.getCutSegments(),
+      facePolygons: this.cutter.getResultFacePolygons() as any,
+      faceAdjacency: this.cutter.getResultFaceAdjacency()
+    });
+    const explanation = generateExplanation({
+      snapIds,
+      outlineRefs: this.cutter.getOutlineRefs(),
+      structure
+    });
+    this.ui.setExplanation(explanation);
+  }
+}


### PR DESCRIPTION
Closes #141

## 概要
- CutService を新設し、cut 実行フローを main から移譲
- main は orchestrator として簡素化

## 経緯
- main.executeCut が多責務だったため分離

## 実装上の留意点
- CutService が Cutter / ObjectModelManager / UI / Selection を統括
- 既存 API を保ちつつ呼び出し側を整理

## レビューしてほしい点
- CutService の責務と境界の妥当性
- main 側の役割が十分に軽くなっているか

## テスト
- `npm run typecheck`
- `npm run build`
- `npx vitest run`

## L2 ドキュメント
- なし

## リファクタリング前の状態
- main.executeCut が UI/SSOT/CSG/説明生成を包含

## リファクタリング後の状態
- CutService に移譲し main は orchestrator に限定
