### PR TITLE
[#142] TopologyIndex の注入方式整理

### DIFF
--- a/js/Cutter.ts
+++ b/js/Cutter.ts
@@ -76,6 +76,10 @@ export class Cutter {
     this.debug = !!debug;
   }
 
+  setTopologyIndex(topologyIndex: TopologyIndex | null) {
+    this.lastTopologyIndex = topologyIndex;
+  }
+
   setShowNormalHelper(visible: boolean) {
     this.visualization.setShowNormalHelper(visible, this.resultMesh);
   }
@@ -170,7 +174,6 @@ export class Cutter {
         previewOnly?: boolean;
         suppressOutline?: boolean;
         suppressMarkers?: boolean;
-        topologyIndex?: TopologyIndex | null;
       } = {}
   ) {
     this.reset();
@@ -178,7 +181,6 @@ export class Cutter {
     this.lastCube = cube;
     this.lastSnapIds = null;
     this.lastResolver = resolver || null;
-    this.lastTopologyIndex = options.topologyIndex || null;
     const previewOnly = !!options.previewOnly;
     const suppressOutline = !!options.suppressOutline;
     const suppressMarkers = !!options.suppressMarkers;
@@ -1145,8 +1147,7 @@ export class Cutter {
   computeCutState(
     solid: SolidSSOT | any,
     snapIds: SnapPointID[],
-    resolver: any,
-    topologyIndex: TopologyIndex | null = null
+    resolver: any
   ): {
     intersections: IntersectionPoint[];
     facePolygons: CutFacePolygon[];
@@ -1155,7 +1156,6 @@ export class Cutter {
     outlineRefs: IntersectionPoint[];
     cutPlane: THREE.Plane;
   } | null {
-    this.lastTopologyIndex = topologyIndex;
-    return computeCutState(solid, snapIds, resolver, topologyIndex);
+    return computeCutState(solid, snapIds, resolver, this.lastTopologyIndex);
   }
 }

--- a/js/cutter/CutService.ts
+++ b/js/cutter/CutService.ts
@@ -41,8 +41,9 @@ export class CutService {
     const solid = this.objectModelManager.getModel()?.ssot;
     if (!solid) return false;
     const topologyIndex = this.objectModelManager.getModel()?.derived.topologyIndex || null;
+    this.cutter.setTopologyIndex(topologyIndex);
 
-    const success = this.cutter.cut(solid, ids, this.resolver, { topologyIndex });
+    const success = this.cutter.cut(solid, ids, this.resolver);
     if (!success) {
       console.warn("切断処理に失敗しました。点を選択し直してください。");
       this.selection.reset();
@@ -53,7 +54,7 @@ export class CutService {
     const modelDisplay = this.objectModelManager.getDisplayState();
     this.cutter.setTransparency(modelDisplay.cubeTransparent);
 
-    const cutState = this.cutter.computeCutState(solid, ids, this.resolver, topologyIndex);
+    const cutState = this.cutter.computeCutState(solid, ids, this.resolver);
 
     if (cutState) {
       this.objectModelManager.syncCutState({


### PR DESCRIPTION
Closes #142

## 概要
- TopologyIndex を `Cutter.setTopologyIndex()` で注入する方式に統一
- `CutService` から注入を集約し、`cut` の options 依存を除去

## 経緯
- TopologyIndex の受け渡しが散在していたため整理

## 実装上の留意点
- `cut` / `computeCutState` は注入済みの TopologyIndex を参照
- 呼び出し元は CutService に集約

## レビューしてほしい点
- 注入タイミングの妥当性
- 既存 API 互換性

## テスト
- `npm run typecheck`
- `npm run build`
- `npx vitest run`

## L2 ドキュメント
- なし

## リファクタリング前の状態
- TopologyIndex が options 渡しで散在

## リファクタリング後の状態
- setTopologyIndex に集約
