### PR TITLE
[#176] [BUG] 展開時に切断面のみ展開させない

### DIFF
--- a/docs/L2_implementation/176_unfold_cut_face_exclusion.md
+++ b/docs/L2_implementation/176_unfold_cut_face_exclusion.md
@@ -1,0 +1,15 @@
+# 176 unfold cut face exclusion
+
+- 実装(技術)について
+  - NetPlan 生成時に cutFace を除外できるよう `excludeFaceIds` を追加し、adjacency をフィルタして hinges/faceOrder を構築した。
+  - Net 展開時の選択で cutFace を除外し、底面選択の対象から外した。
+  - applyNetPlan 実行前に全 face mesh の姿勢を初期化し、除外面が展開途中の姿勢を保持しないようにした。
+
+- 仕様(L1ドキュメント)について
+  - SSOT の Face は保持しつつ、NetPlan は展開対象のみを扱う運用とし、構造主導を維持した。
+
+- 数学的観点から
+  - 断面の回転を排除しても、hinge を持つ面の相対回転計算は従来通り dihedral angle を用いるため、面同士の幾何整合は保たれる。
+
+- ユーザー体験(ユーザー価値)について
+  - 展開時に断面が動かず、学習時の混乱（断面が展開図に混入する）を避けられる。

--- a/js/Cube.ts
+++ b/js/Cube.ts
@@ -169,6 +169,10 @@ export class Cube {
     if (!plan || !this.resolver) return;
 
     const { rootFaceId, hinges } = plan;
+    this.faceMeshes.forEach(mesh => {
+      mesh.position.set(0, 0, 0);
+      mesh.quaternion.set(0, 0, 0, 1);
+    });
     // Map to store world poses of each face during unfolding
     const worldPoses = new Map<string, { position: THREE.Vector3, quaternion: THREE.Quaternion }>();
     const progressForFace = (faceId: FaceID) => {


### PR DESCRIPTION
Closes #176

## 概要
- cut face を Net 展開対象から除外し、展開時に回転しないようにする。

## 経緯
- 切断面が展開図に混入し学習上の混乱が出るため、展開対象から除外する要件を追加。

## 実装上の留意点
- NetPlan 生成時に excludeFaceIds を受け取り、hinges/faceOrder を除外済みの面で構築。
- Net 選択時に cut face を選べないようにフィルタ。
- applyNetPlan 前に face mesh を初期化し、除外面が中間姿勢を保持しないようにした。

## レビューしてほしい点
- 展開時に cut face が除外されること（回転しない/選択不可）。
- 断面以外の面の位置関係が崩れないこと。

## L2 ドキュメント
- docs/L2_implementation/176_unfold_cut_face_exclusion.md

### バグの原因
- 切断面も通常 Face として NetPlan の BFS に含まれていたため、展開対象に入っていた。

### 修正内容
- NetPlan 生成で cut face を除外するオプションを追加し、main から渡す。
- Net の面選択対象から cut face を除外。
- 展開開始時に全 face mesh を初期姿勢へリセット。
