### PR TITLE
[#186] Refactor: group net selection messages

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,15 @@ import type { ObjectNetState, NetPlan } from './js/model/objectModel.js';
 import { normalizeSnapPointId, parseSnapPointId, type SnapPointID } from './js/geometry/snapPointId.js';
 import { createLabel, createMarker } from './js/utils.js';
 
+const NET_SELECTION_MESSAGES = {
+    selectPrompt: "基準面を選択してください。",
+    cancel: "基準面選択をキャンセルしました。",
+    confirmStep: "基準面を確定しました。ステップで展開します。",
+    confirmAuto: "基準面を確定しました。展開します。"
+} as const;
+
+type NetSelectionMessageKey = keyof typeof NET_SELECTION_MESSAGES;
+
 const isDebugEnabled = () => {
     const flag = (globalThis as any).__DEBUG__ === true || (globalThis as any).DEBUG === true;
     if (flag) return true;
@@ -2369,6 +2378,10 @@ class App {
         this.clearNetSelectionHighlight();
     }
 
+    showNetSelectionMessage(key: NetSelectionMessageKey) {
+        this.ui.showMessage(NET_SELECTION_MESSAGES[key], "info");
+    }
+
     startNetBaseSelection() {
         this.netSelectionActive = true;
         this.netRootFaceId = null;
@@ -2377,7 +2390,7 @@ class App {
         this.highlightMarker.visible = false;
         this.snappedPointInfo = null;
         document.body.style.cursor = 'pointer';
-        this.ui.showMessage("基準面を選択してください。", "info");
+        this.showNetSelectionMessage('selectPrompt');
     }
 
     startNetPreCameraMove({
@@ -2414,7 +2427,7 @@ class App {
         if (!this.objectModelManager.getNetVisible()) {
             this.cube.setFaceOutlineVisible(false);
         }
-        this.ui.showMessage("基準面選択をキャンセルしました。", "info");
+        this.showNetSelectionMessage('cancel');
         document.body.style.cursor = 'auto';
     }
 
@@ -2580,7 +2593,7 @@ class App {
                                 }
                                 this.clearNetSelectionHighlight();
                                 this.updateNetStepUi();
-                                this.ui.showMessage("基準面を確定しました。ステップで展開します。", "info");
+                                this.showNetSelectionMessage('confirmStep');
                                 return;
                             }
                             this.startNetUnfold();
@@ -2588,7 +2601,7 @@ class App {
                             if (solid) {
                                 this.netManager.update(this.objectModelManager.getCutSegments(), solid, this.resolver);
                             }
-                            this.ui.showMessage("基準面を確定しました。展開します。", "info");
+                            this.showNetSelectionMessage('confirmAuto');
                         }, 1500);
                     }
                 });


### PR DESCRIPTION
Closes #186

## 概要
- Net基準面選択メッセージを定数/ヘルパーに集約
- 文言は現状を維持

## 経緯
- メッセージの分散を抑えて変更点を局所化

## 実装上の留意点
- 表示文言の既存挙動を変更しない

## レビューしてほしい点
- Net選択フローの表示に影響がないか

## L2ドキュメント
- なし

## リファクタリング前の状態
- Net選択メッセージが `main.ts` 内に散在

## リファクタリング後の状態
- 定数とヘルパーで集約
