### PR TITLE
[#191] [BUG] モバイル表示で縦長/操作困難

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <title>立体切断シミュレーター v0.3</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">


### PR DESCRIPTION
Closes #191

## 概要
- viewport meta を追加し、モバイル表示の倍率/高さスケールを正しく反映

## 経緯
- iPhone 12 mini で縦長＆UIが極小になる現象の修正

## レビューしてほしい点
- モバイルでの表示サイズ/操作性が改善しているか

## L2ドキュメント
- なし

## バグの原因
- viewport meta が無く、モバイルでデフォルトの仮想幅/縮小表示になっていた

## 修正内容
- `index.html` に viewport meta を追加
