### PR TITLE
[#195] [BUG] Net playback state sync でスタックオーバーフロー

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1594,7 +1594,9 @@ class App {
         state?: ObjectNetState['state'];
         progress?: number;
         applyStepState?: boolean;
+        syncNetState?: boolean;
     } = {}) {
+        const shouldSync = partial.syncNetState !== false;
         const hasPlaybackMode = partial.playbackMode !== undefined;
         const hasStepIndex = Number.isFinite(partial.stepIndex as number);
         if (hasPlaybackMode) {
@@ -1606,7 +1608,7 @@ class App {
         if (partial.applyStepState) {
             this.applyNetStepState(this.netStepIndex);
         }
-        if (hasPlaybackMode || hasStepIndex || partial.state !== undefined || partial.progress !== undefined) {
+        if (shouldSync && (hasPlaybackMode || hasStepIndex || partial.state !== undefined || partial.progress !== undefined)) {
             const sync: Partial<ObjectNetState> = {};
             if (hasPlaybackMode) sync.playbackMode = partial.playbackMode!;
             if (hasStepIndex) sync.stepIndex = partial.stepIndex as number;
@@ -1734,7 +1736,10 @@ class App {
         if (Number.isFinite(state.stepIndex)) {
             playbackUpdate.stepIndex = state.stepIndex;
         }
-        this.updateNetPlaybackState(playbackUpdate);
+        this.updateNetPlaybackState({
+            ...playbackUpdate,
+            syncNetState: false
+        });
     }
 
     setNetAnimationState(partial: {


### PR DESCRIPTION
Closes #195

## 概要
- Net state 同期での循環呼び出しを抑止

## 経緯
- `updateNetPlaybackState` が `syncNetState` → notify → `applyNetStateFromModel` を呼び続けていた

## レビューしてほしい点
- プリセット/学習モードボタン操作時のエラーが解消されるか
- Net UI の状態表示が維持されるか

## L2ドキュメント
- なし

## バグの原因
- モデル反映時も `updateNetPlaybackState` が `syncNetState` を実行し、無限再入した

## 修正内容
- `updateNetPlaybackState` に `syncNetState` フラグを追加し、モデル反映経路では同期を抑止
