### PR TITLE
[#197] [ENH] モード基盤（回転/切断/展開）

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@ html, body { margin:0; width:100%; height:100%; overflow:hidden; }
     --message-area-left: 0px;
     --message-area-width: 100%;
     --navbar-height: 0px;
+    --mode-bar-height: 52px;
 }
 #ui-container {
     position: absolute; top: 0; left: 0; width: 100%; z-index: 100;
@@ -79,6 +80,37 @@ html, body { margin:0; width:100%; height:100%; overflow:hidden; }
 }
 #message-area .alert .btn-close {
     display: none;
+}
+.mode-bar {
+    position: fixed;
+    top: calc(var(--message-area-top) + var(--message-area-height));
+    left: var(--message-area-left);
+    width: var(--message-area-width);
+    height: var(--mode-bar-height);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    z-index: 1501;
+    pointer-events: auto;
+}
+.mode-bar .mode-button {
+    background: #f6c945;
+    border: 1px solid rgba(0,0,0,0.2);
+    color: #2d2308;
+    border-radius: 999px;
+    padding: 8px 16px;
+    font-weight: 700;
+    font-size: 14px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.mode-bar .mode-button.is-active {
+    background: #ffde6a;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+}
+.mode-bar .mode-button:active {
+    transform: translateY(1px);
 }
 .navbar {
     background: var(--ui-muted-bg) !important;
@@ -244,6 +276,7 @@ body {
     <div id="alert-container" style="position: absolute; top: var(--message-area-offset); left: 50%; transform: translateX(-50%); z-index: 2000; width: 80%; max-width: 600px; pointer-events: none;"></div>
   </div>
 </div>
+<div id="mode-bar-root" class="mode-bar"></div>
 <div id="react-side-panel-root"></div>
 <div id="tooltip"></div>
 

--- a/js/ui/side_panel.ts
+++ b/js/ui/side_panel.ts
@@ -30,6 +30,8 @@ type Engine = {
   configureCube?: (lx: number, ly: number, lz: number) => void;
   getCubeSize?: () => { lx: number; ly: number; lz: number };
   setPanelOpen?: (open: boolean) => void;
+  getUiMode?: () => 'rotate' | 'cut' | 'net';
+  setUiMode?: (mode: 'rotate' | 'cut' | 'net') => void;
   getNetVisible?: () => boolean;
   getNetStepInfo?: () => {
     mode: 'auto' | 'step';

--- a/main.ts
+++ b/main.ts
@@ -39,6 +39,7 @@ const isDebugEnabled = () => {
 
 class App {
     isCutExecuted: boolean;
+    uiMode: 'rotate' | 'cut' | 'net';
     currentNetPlan: NetPlan | null;
     snappedPointInfo: {
         point: THREE.Vector3;
@@ -178,6 +179,7 @@ class App {
     constructor() {
         // --- State Properties ---
         this.isCutExecuted = false;
+        this.uiMode = 'rotate';
         this.currentNetPlan = null;
         this.snappedPointInfo = null;
         this.cameraTargetPosition = null;
@@ -380,6 +382,8 @@ class App {
             getCubeSize: () => this.cube.getSize(),
             getVertexLabelMap: () => this.currentLabelMap, // Add this line
             setPanelOpen: (open: boolean) => this.handlePanelOpenChange(open),
+            getUiMode: () => this.uiMode,
+            setUiMode: (mode: 'rotate' | 'cut' | 'net') => this.setUiMode(mode),
             getNetVisible: () => this.objectModelManager.getNetVisible(),
             getNetStepInfo: () => this.getNetStepInfo(),
             getAnimationSpecEnabled: () => this.useAnimationSpecNet,
@@ -950,10 +954,11 @@ class App {
         const panelOffset = panelOffsetOverride ?? (this.panelOpen ? panelWidth : 0);
         const availableWidth = Math.max(200, window.innerWidth - sidebarWidth - panelOffset);
         const messageHeight = Math.round(window.innerHeight * 0.4);
+        const modeBarHeight = 52;
         const navbar = document.querySelector('.navbar') as HTMLElement | null;
         const navbarHeight = Math.round(navbar?.getBoundingClientRect().height ?? 0);
         const messageAreaHeight = Math.max(0, messageHeight - navbarHeight);
-        const availableHeight = Math.max(200, window.innerHeight - messageHeight);
+        const availableHeight = Math.max(200, window.innerHeight - messageHeight - modeBarHeight);
         const rootStyle = document.documentElement.style;
         rootStyle.setProperty('--sidebar-width', `${sidebarWidth}px`);
         rootStyle.setProperty('--panel-offset', `${panelOffset}px`);
@@ -962,12 +967,13 @@ class App {
         rootStyle.setProperty('--message-area-top', `${navbarHeight}px`);
         rootStyle.setProperty('--message-area-left', `${sidebarWidth + panelOffset}px`);
         rootStyle.setProperty('--message-area-width', `${availableWidth}px`);
+        rootStyle.setProperty('--mode-bar-height', `${modeBarHeight}px`);
         this.cube.resize(this.camera, availableWidth, availableHeight);
         this.resolver.setSize(this.cube.getSize());
         this.renderer.setSize(availableWidth, availableHeight);
         const canvas = this.renderer.domElement;
         canvas.style.position = 'fixed';
-        canvas.style.top = `${messageHeight}px`;
+        canvas.style.top = `${messageHeight + modeBarHeight}px`;
         canvas.style.left = `${sidebarWidth + panelOffset}px`;
         this.updateNetUnfoldScale();
     }
@@ -1030,6 +1036,13 @@ class App {
         this.layoutTransitionTo = this.panelOpen ? 320 : 0;
         this.layoutTransitionStart = performance.now();
         this.layoutTransitionActive = true;
+    }
+
+    setUiMode(mode: 'rotate' | 'cut' | 'net') {
+        this.uiMode = mode;
+        if (typeof (globalThis as any).__setUiMode === 'function') {
+            (globalThis as any).__setUiMode(mode);
+        }
     }
     
     handleModeChange(mode: string) {


### PR DESCRIPTION
Closes #197

## 概要
- 回転/切断/展開の3モード状態を導入
- 黒板下にモード切替ボタン（黄色・排他）を追加
- 展開パネル制御のための `getUiMode/setUiMode` を用意

## レビューしてほしい点
- 黒板下にボタンが表示されること
- モード切替が排他的に動作すること

## L2ドキュメント
- なし

## 実装のポイント
- モード状態は App 内で保持し、React UI と同期

## 実装時の注意点
- 黒板領域とキャンバスのオフセット調整

## その他留意事項
- 操作制御/展開フローは次Issueで対応
