### PR TITLE
[#198] [ENH] 回転/切断モードの操作制御

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -304,6 +304,8 @@ class App {
         this.controls = new OrbitControls(this.camera, this.renderer.domElement);
         this.controls.enableDamping = true;
         this.controls.target.set(0, 0, 0);
+        this.controls.enableRotate = this.uiMode === 'rotate';
+        this.controls.enableZoom = true;
         this.controls.update();
 
         this.raycaster = new THREE.Raycaster();
@@ -519,6 +521,9 @@ class App {
     executeCut() {
         const success = this.cutService.executeCut();
         this.isCutExecuted = !!success;
+        if (success && this.uiMode === 'cut') {
+            this.setUiMode('rotate');
+        }
     }
 
     finalizeResetScene() {
@@ -1042,6 +1047,10 @@ class App {
         this.uiMode = mode;
         if (typeof (globalThis as any).__setUiMode === 'function') {
             (globalThis as any).__setUiMode(mode);
+        }
+        if (this.controls) {
+            this.controls.enableRotate = mode === 'rotate';
+            this.controls.enableZoom = true;
         }
     }
     


### PR DESCRIPTION
Closes #198

## 概要
- 回転/切断モードで回転操作の可否を切替
- 切断成功時は回転モードへ自動復帰

## レビューしてほしい点
- 切断モードで回転が無効になること
- 切断後に回転モードへ戻ること

## L2ドキュメント
- なし

## 実装のポイント
- `setUiMode` で OrbitControls を更新
- `executeCut` 成功時にモード復帰

## 実装時の注意点
- ズームは全モードで有効
