### PR TITLE
[#199] [ENH] 展開モードのUI/フロー

### DIFF
--- a/js/ui/reactApp.ts
+++ b/js/ui/reactApp.ts
@@ -44,6 +44,10 @@ type Engine = {
   setPanelOpen?: (open: boolean) => void;
   getUiMode?: () => 'rotate' | 'cut' | 'net';
   setUiMode?: (mode: 'rotate' | 'cut' | 'net') => void;
+  startNetSelection?: () => void;
+  startNetUnfold?: () => void;
+  startNetFold?: () => void;
+  getNetStateName?: () => string;
   getNetVisible?: () => boolean;
   getNetStepInfo?: () => {
     mode: 'auto' | 'step';


### PR DESCRIPTION
Closes #199

## 概要
- 展開モード用の操作パネルを追加し、基準面選択→開始/ステップ操作の流れを明確化
- 展開モード切替時に黒板へ案内メッセージを表示
- 展開開始は「開始」ボタンで明示的にトリガー

## レビューしてほしい点
- 展開モードに入るとパネルが表示されること
- 「基準面を選ぶ」押下後にのみホバー色が変化すること
- 自動展開ON/OFFでUIが切り替わること

## L2ドキュメント
- なし

## 実装のポイント
- `startNetSelection`/`startNetUnfold`/`startNetFold` をUIから明示的に呼び出し
- 自動展開の初期値をONに設定

## 実装時の注意点
- 既存の net 展開ロジックの自動開始を抑止
