### PR TITLE
[#203] [ENH] 展開モードでも回転/ズームを許可

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1062,7 +1062,7 @@ class App {
             this.cancelNetBaseSelection();
         }
         if (this.controls) {
-            this.controls.enableRotate = mode === 'rotate';
+            this.controls.enableRotate = mode !== 'cut';
             this.controls.enableZoom = true;
         }
     }


### PR DESCRIPTION
Closes #203

## 概要
- 展開モードでも回転操作を許可
- ズームは全モードで維持

## レビューしてほしい点
- 展開モードで回転できること
- 切断モードでは回転不可のまま

## L2ドキュメント
- なし

## 実装のポイント
- `setUiMode` で `enableRotate` をモードに応じて切替
