### PR TITLE
[#205] [BUG] リセットボタンが動作しない

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1357,6 +1357,7 @@ class App {
     }
 
     handleResetClick() {
+        this.resetScene();
         this.handleModeChange('free');
         if (!this.useReactPresets) {
             this.ui.resetToFreeSelectMode();


### PR DESCRIPTION
Closes #205

## 概要
- リセットボタンで `resetScene` が呼ばれるよう修正

## レビューしてほしい点
- リセットボタンでシーンが初期化されること

## L2ドキュメント
- なし

## バグの原因
- `handleResetClick` が `resetScene` を呼ばず、モード切替のみになっていた

## 修正内容
- `handleResetClick` に `resetScene` を追加
